### PR TITLE
fix(license): make exceptions reliable across Helm and GitOps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,6 @@ jobs:
 
       - name: Lint chart
         run: helm lint deploy/helm/bomhort/
+
+      - name: Test license exceptions templates
+        run: python3 -B -m unittest discover -s deploy/helm/tests -v

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Two JSON config files control license governance. Edit them and restart the affe
 | File | Mounted in | Purpose |
 |------|-----------|---------|
 | `sboms/license-policy.json` | API Gateway, Workers | Defines which SPDX IDs are **permissive** vs. **copyleft**. Anything not listed = `unknown`. |
-| `sboms/license-exceptions.json` | API Gateway, Workers | Exempts specific licenses (blanket) or package+license combos from violation reporting. [CNCF format](https://github.com/cncf/foundation/blob/main/license-exceptions/exceptions.json). |
+| `sboms/license-exceptions.json` | API Gateway, Workers | Empty by default. Explicit organization-approved blanket or package/license/project exceptions. [Structure and configuration](examples/license-exceptions/README.md). |
 
 ### Custom Theme (CSS)
 
@@ -501,11 +501,21 @@ By default, BOMHort enforces the [CNCF Allowed Third-Party License Policy](https
 - **Copyleft (flagged):** GPL, LGPL, AGPL, MPL-2.0, EPL, EUPL, CPAL, and others (21 total)
 - **Unknown:** Any license not in either list is flagged for review
 
-### CNCF Exception List
+### License Exceptions
 
-The [CNCF license exceptions](https://github.com/cncf/foundation/blob/main/license-exceptions/exceptions.json) are automatically downloaded and applied. Packages covered by a CNCF Governing Board exception are marked as exempted rather than non-compliant.
+No exceptions are enabled or downloaded by default. Configure only approvals that
+apply to your organization using `licenseExceptions.custom` (a YAML object or JSON
+string), or `--set-file licenseExceptions.custom=./my-exceptions.json` with Helm.
+Docker Compose uses the initially empty `sboms/license-exceptions.json`.
 
-Exceptions with `"project": "All CNCF Projects"` are treated as blanket exceptions (apply to every SBOM).
+The [inactive example and migration guide](examples/license-exceptions/README.md)
+describe the structure and matching rules. Package exceptions stay package-scoped;
+`project` restricts them to an exact SBOM document name. There is no CNCF-specific
+blanket promotion. An empty configuration is authoritative and does not fall back
+to old approvals in the SBOM directory.
+
+Helm changes roll out both API and workers. **Re-process existing SBOMs** to update
+stored results after changing approvals; a watcher run alone skips unchanged files.
 
 ### Customising the Policy
 

--- a/backend/cmd/api-gateway/license_exceptions.go
+++ b/backend/cmd/api-gateway/license_exceptions.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/seebom-labs/bomhort/backend/internal/license"
+)
+
+func loadRequestExceptions(w http.ResponseWriter, paths ...string) (*license.ExceptionIndex, bool) {
+	idx, err := license.LoadExceptionsWithFallback(paths...)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Printf("ERROR: license exceptions configuration: %v", err)
+		writeError(w, http.StatusInternalServerError, "Invalid license exceptions configuration")
+		return nil, false
+	}
+	return idx, true
+}
+
+func licenseExceptionsHandler(paths ...string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idx, ok := loadRequestExceptions(w, paths...)
+		if !ok {
+			return
+		}
+		if idx == nil {
+			writeJSON(w, http.StatusOK, license.ExceptionsFile{
+				Version:           "1.0.0",
+				BlanketExceptions: []license.BlanketException{},
+				Exceptions:        []license.Exception{},
+			})
+			return
+		}
+		writeJSON(w, http.StatusOK, idx.Raw)
+	}
+}

--- a/backend/cmd/api-gateway/license_exceptions_test.go
+++ b/backend/cmd/api-gateway/license_exceptions_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLicenseExceptionsHandler(t *testing.T) {
+	const empty = `{"blanketExceptions":[],"exceptions":[]}`
+	const full = `{"blanketExceptions":[],"exceptions":[{"id":"own-rule","package":"library","license":"MPL-2.0","status":"approved"}]}`
+	for _, tt := range []struct {
+		name, primary, fallback string
+		status, rules           int
+	}{
+		{"missing", "", "", http.StatusOK, 0},
+		{"empty primary overrides fallback", empty, full, http.StatusOK, 0},
+		{"configured", full, "", http.StatusOK, 1},
+		{"missing primary uses fallback", "", full, http.StatusOK, 1},
+		{"invalid primary", `{`, full, http.StatusInternalServerError, 0},
+		{"incorrect template keys", `{"blanket_exceptions":[],"exceptions":[]}`, full, http.StatusInternalServerError, 0},
+		{"invalid fallback", "", `{`, http.StatusInternalServerError, 0},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			paths := []string{filepath.Join(dir, "primary.json"), filepath.Join(dir, "fallback.json")}
+			for i, content := range []string{tt.primary, tt.fallback} {
+				if content != "" {
+					if err := os.WriteFile(paths[i], []byte(content), 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			w := httptest.NewRecorder()
+			licenseExceptionsHandler(paths...).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/license-exceptions", nil))
+			if w.Code != tt.status {
+				t.Fatalf("status = %d, want %d; body=%s", w.Code, tt.status, w.Body.String())
+			}
+			if tt.status != http.StatusOK {
+				return
+			}
+			var response map[string]json.RawMessage
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			if string(response["blanketExceptions"]) != "[]" {
+				t.Fatalf("expected camelCase blanketExceptions array: %s", w.Body.String())
+			}
+			var rules []json.RawMessage
+			if err := json.Unmarshal(response["exceptions"], &rules); err != nil {
+				t.Fatal(err)
+			}
+			if len(rules) != tt.rules {
+				t.Fatalf("got %d rules, want %d", len(rules), tt.rules)
+			}
+		})
+	}
+}

--- a/backend/cmd/api-gateway/main.go
+++ b/backend/cmd/api-gateway/main.go
@@ -248,7 +248,10 @@ func main() {
 	// Projects with non-compliant licenses (filtered by exceptions).
 	mux.HandleFunc("GET /api/v1/projects/license-compliance", func(w http.ResponseWriter, r *http.Request) {
 		// Load current exceptions for filtering (try config path, then SBOM dir).
-		excIdx, _ := license.LoadExceptionsWithFallback(exceptionsPath, sbomDirExceptionsPath)
+		excIdx, ok := loadRequestExceptions(w, exceptionsPath, sbomDirExceptionsPath)
+		if !ok {
+			return
+		}
 		violations, err := chClient.QueryProjectsWithLicenseViolations(r.Context(), excIdx)
 		if err != nil {
 			log.Printf("ERROR: license violations: %v", err)
@@ -330,18 +333,7 @@ func main() {
 	})
 
 	// ── License Exceptions (read-only from config file or SBOM dir) ────
-	mux.HandleFunc("GET /api/v1/license-exceptions", func(w http.ResponseWriter, r *http.Request) {
-		idx, err := license.LoadExceptionsWithFallback(exceptionsPath, sbomDirExceptionsPath)
-		if err != nil || idx == nil {
-			writeJSON(w, http.StatusOK, license.ExceptionsFile{
-				Version:           "1.0.0",
-				BlanketExceptions: []license.BlanketException{},
-				Exceptions:        []license.Exception{},
-			})
-			return
-		}
-		writeJSON(w, http.StatusOK, idx.Raw)
-	})
+	mux.HandleFunc("GET /api/v1/license-exceptions", licenseExceptionsHandler(exceptionsPath, sbomDirExceptionsPath))
 
 	// ── License Policy (read-only, permissive/copyleft classification) ─
 	mux.HandleFunc("GET /api/v1/license-policy", func(w http.ResponseWriter, r *http.Request) {

--- a/backend/cmd/parsing-worker/main.go
+++ b/backend/cmd/parsing-worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -57,6 +58,9 @@ func main() {
 		log.Printf("Loaded license exceptions (%d blanket, %d specific)",
 			len(idx.Raw.BlanketExceptions), len(idx.Raw.Exceptions))
 	} else {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Fatalf("Invalid license exceptions configuration: %v", err)
+		}
 		log.Printf("No license exceptions loaded (tried %s, %s): %v", cfg.ExceptionsFile, sbomDirExceptionsPath, err)
 	}
 
@@ -406,7 +410,7 @@ func processSBOMJob(ctx context.Context, cfg *config.Config, chClient *clickhous
 	}
 
 	// 6. License compliance check (uses the already-resolved licenses).
-	licResults := license.CheckWithExceptions(result.Packages.PackageNames, result.Packages.PackageLicenses, exceptions)
+	licResults := license.CheckWithExceptions(result.Packages.PackageNames, result.Packages.PackageLicenses, exceptions, result.SBOM.DocumentName)
 	if len(licResults) > 0 {
 		licModels := make([]models.LicenseCompliance, len(licResults))
 		for i, lr := range licResults {

--- a/backend/internal/clickhouse/queries_search.go
+++ b/backend/internal/clickhouse/queries_search.go
@@ -252,7 +252,7 @@ func (c *Client) QueryProjectsWithLicenseViolations(ctx context.Context, excepti
 		var violatingPkgs []string
 		for _, pkg := range packages {
 			if exceptions != nil {
-				if exempt, _ := exceptions.IsExempt(pkg, licenseID); exempt {
+				if exempt, _ := exceptions.IsExempt(pkg, licenseID, documentName); exempt {
 					continue
 				}
 			}

--- a/backend/internal/license/checker.go
+++ b/backend/internal/license/checker.go
@@ -173,7 +173,8 @@ func Check(packageNames, packageLicenses []string) []Result {
 
 // CheckWithExceptions analyzes packages/licenses with optional exception rules.
 // Exempted packages are tracked separately and don't count as non-compliant.
-func CheckWithExceptions(packageNames, packageLicenses []string, exceptions *ExceptionIndex) []Result {
+// project is the exact SBOM document name for project-scoped rules.
+func CheckWithExceptions(packageNames, packageLicenses []string, exceptions *ExceptionIndex, project ...string) []Result {
 	type licenseAgg struct {
 		count         uint32
 		packages      []string
@@ -223,7 +224,7 @@ func CheckWithExceptions(packageNames, packageLicenses []string, exceptions *Exc
 			// Permissive licenses are always compliant – don't track packages.
 		} else if exceptions != nil {
 			// Copyleft or unknown: check per-package exception.
-			if exempt, _ := exceptions.IsExempt(name, lic); exempt {
+			if exempt, _ := exceptions.IsExempt(name, lic, project...); exempt {
 				entry.exempted = append(entry.exempted, name)
 			} else {
 				entry.packages = append(entry.packages, name)

--- a/backend/internal/license/checker_test.go
+++ b/backend/internal/license/checker_test.go
@@ -169,6 +169,12 @@ func TestCheckWithExceptions_PackageExempt(t *testing.T) {
 }
 
 func TestLoadPolicy(t *testing.T) {
+	previous := activePolicy
+	t.Cleanup(func() {
+		policyMu.Lock()
+		activePolicy = previous
+		policyMu.Unlock()
+	})
 	policyJSON := `{
 		"permissive": ["MIT", "Apache-2.0", "BSD-3-Clause"],
 		"copyleft": ["GPL-3.0-only", "AGPL-3.0-only"]
@@ -296,8 +302,7 @@ func TestLoadExceptionsWithFallback_PrimaryPath(t *testing.T) {
 }
 
 func TestLoadExceptionsWithFallback_FallbackPath(t *testing.T) {
-	// Primary has empty exceptions, fallback has real data.
-	emptyJSON := `{"version":"1.0.0","blanketExceptions":[],"exceptions":[]}`
+	// Only a missing primary permits using the fallback.
 	fullJSON := `{
 		"version": "1.0.0",
 		"blanketExceptions": [
@@ -308,9 +313,6 @@ func TestLoadExceptionsWithFallback_FallbackPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	primary := filepath.Join(tmpDir, "primary.json")
 	fallback := filepath.Join(tmpDir, "fallback.json")
-	if err := os.WriteFile(primary, []byte(emptyJSON), 0644); err != nil {
-		t.Fatal(err)
-	}
 	if err := os.WriteFile(fallback, []byte(fullJSON), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -371,8 +373,8 @@ func TestCheck_MismatchedLengths(t *testing.T) {
 	_ = results
 }
 
-func TestBuildIndex_AllCNCFProjectsPromotedToBlanket(t *testing.T) {
-	// CNCF exceptions with "All CNCF Projects" should be treated as blanket exceptions.
+func TestBuildIndex_AllCNCFProjectsNeverPromotedToBlanket(t *testing.T) {
+	// A project label must never remove the package restriction.
 	ef := &ExceptionsFile{
 		Exceptions: []Exception{
 			{
@@ -387,18 +389,18 @@ func TestBuildIndex_AllCNCFProjectsPromotedToBlanket(t *testing.T) {
 	}
 	idx := BuildIndex(ef)
 
-	// Both GPL-2.0-only and GPL-2.0-or-later should be blanket-exempted.
+	// Neither license is exempt for unrelated packages or projects.
 	exempt, reason := idx.IsExempt("any-package", "GPL-2.0-only")
-	if !exempt {
-		t.Error("expected GPL-2.0-only to be blanket exempted via All CNCF Projects")
+	if exempt {
+		t.Error("unrelated package must not be exempt")
 	}
-	if reason == "" {
-		t.Error("expected non-empty reason")
+	if reason != "" {
+		t.Error("expected no exemption reason")
 	}
 
 	exempt2, _ := idx.IsExempt("another-package", "GPL-2.0-or-later")
-	if !exempt2 {
-		t.Error("expected GPL-2.0-or-later to be blanket exempted via All CNCF Projects")
+	if exempt2 {
+		t.Error("unrelated package must not be exempt")
 	}
 
 	// Non-listed license should NOT be exempt.
@@ -415,7 +417,7 @@ func TestBuildIndex_CompoundLicenseOR(t *testing.T) {
 				ID:      "exc-libpathrs",
 				Package: "libpathrs",
 				License: "MPL-2.0 OR LGPL-3.0-or-later",
-				Project: "All CNCF Projects",
+				Project: "*",
 				Status:  "approved",
 				Comment: "libpathrs blanket exception",
 			},
@@ -423,14 +425,14 @@ func TestBuildIndex_CompoundLicenseOR(t *testing.T) {
 	}
 	idx := BuildIndex(ef)
 
-	// Both MPL-2.0 and LGPL-3.0-or-later should be blanket-exempted.
-	exempt, _ := idx.IsExempt("any-pkg", "MPL-2.0")
+	// Both licenses are exempt only for the named package.
+	exempt, _ := idx.IsExempt("libpathrs", "MPL-2.0")
 	if !exempt {
-		t.Error("expected MPL-2.0 to be blanket exempted")
+		t.Error("expected MPL-2.0 package exception")
 	}
-	exempt2, _ := idx.IsExempt("any-pkg", "LGPL-3.0-or-later")
+	exempt2, _ := idx.IsExempt("libpathrs", "LGPL-3.0-or-later")
 	if !exempt2 {
-		t.Error("expected LGPL-3.0-or-later to be blanket exempted")
+		t.Error("expected LGPL-3.0-or-later package exception")
 	}
 }
 
@@ -441,7 +443,7 @@ func TestBuildIndex_CompoundLicenseAND(t *testing.T) {
 				ID:      "exc-securejoin",
 				Package: "cyphar/filepath-securejoin",
 				License: "MPL-2.0 AND BSD-3-Clause",
-				Project: "All CNCF Projects",
+				Project: "*",
 				Status:  "approved",
 				Comment: "filepath-securejoin blanket exception",
 			},
@@ -449,18 +451,18 @@ func TestBuildIndex_CompoundLicenseAND(t *testing.T) {
 	}
 	idx := BuildIndex(ef)
 
-	// Both MPL-2.0 and BSD-3-Clause should be blanket-exempted.
-	exempt, _ := idx.IsExempt("any-pkg", "MPL-2.0")
+	// Both licenses are exempt only for the named package.
+	exempt, _ := idx.IsExempt("cyphar/filepath-securejoin", "MPL-2.0")
 	if !exempt {
-		t.Error("expected MPL-2.0 to be blanket exempted via AND split")
+		t.Error("expected MPL-2.0 package exception via AND split")
 	}
-	exempt2, _ := idx.IsExempt("any-pkg", "BSD-3-Clause")
+	exempt2, _ := idx.IsExempt("cyphar/filepath-securejoin", "BSD-3-Clause")
 	if !exempt2 {
-		t.Error("expected BSD-3-Clause to be blanket exempted via AND split")
+		t.Error("expected BSD-3-Clause package exception via AND split")
 	}
 }
 
-func TestIsExempt_SubstringPackageMatch(t *testing.T) {
+func TestIsExempt_PathSuffixPackageMatch(t *testing.T) {
 	// CNCF exception uses short name, SBOM has full qualified name.
 	ef := &ExceptionsFile{
 		Exceptions: []Exception{
@@ -476,8 +478,8 @@ func TestIsExempt_SubstringPackageMatch(t *testing.T) {
 	}
 	idx := BuildIndex(ef)
 
-	// Full Go module path should match via substring.
-	exempt, reason := idx.IsExempt("github.com/cyphar/filepath-securejoin", "MPL-2.0")
+	// Full Go module path matches a complete suffix within the project.
+	exempt, reason := idx.IsExempt("github.com/cyphar/filepath-securejoin", "MPL-2.0", "containerd")
 	if !exempt {
 		t.Error("expected substring match for github.com/cyphar/filepath-securejoin")
 	}
@@ -486,13 +488,13 @@ func TestIsExempt_SubstringPackageMatch(t *testing.T) {
 	}
 
 	// Exact match should also work.
-	exempt2, _ := idx.IsExempt("cyphar/filepath-securejoin", "MPL-2.0")
+	exempt2, _ := idx.IsExempt("cyphar/filepath-securejoin", "MPL-2.0", "containerd")
 	if !exempt2 {
 		t.Error("expected exact match for cyphar/filepath-securejoin")
 	}
 
 	// Non-matching package should NOT be exempt.
-	exempt3, _ := idx.IsExempt("github.com/other/package", "MPL-2.0")
+	exempt3, _ := idx.IsExempt("github.com/other/package", "MPL-2.0", "containerd")
 	if exempt3 {
 		t.Error("expected non-matching package to NOT be exempt")
 	}

--- a/backend/internal/license/exceptions.go
+++ b/backend/internal/license/exceptions.go
@@ -1,15 +1,18 @@
 package license
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
 	json "github.com/goccy/go-json"
 )
 
-// ExceptionsFile represents the top-level license-exceptions.json structure,
-// modeled after https://github.com/cncf/foundation/blob/main/license-exceptions/exceptions.json
+// ExceptionsFile represents operator-managed license exceptions.
+// No organization-specific approvals are implied by this format.
 type ExceptionsFile struct {
 	Version           string             `json:"version"`
 	LastUpdated       string             `json:"lastUpdated"`
@@ -31,9 +34,9 @@ type BlanketException struct {
 // Exception exempts a specific package+license combination.
 type Exception struct {
 	ID           string `json:"id"`
-	Package      string `json:"package"`           // package name or PURL pattern
+	Package      string `json:"package"`           // package name, exact or path-segment suffix
 	License      string `json:"license"`           // SPDX license ID
-	Project      string `json:"project,omitempty"` // optional: restrict to specific project
+	Project      string `json:"project,omitempty"` // exact SBOM document name; empty or * means all
 	Status       string `json:"status"`            // approved, revoked
 	ApprovedDate string `json:"approvedDate"`
 	Scope        string `json:"scope,omitempty"`
@@ -46,9 +49,11 @@ type ExceptionIndex struct {
 	// blanketLicenses are licenses globally exempted (exact match on SPDX ID).
 	blanketLicenses map[string]*BlanketException
 	// packageLicense maps "package\x00license" → Exception for specific package+license pairs.
-	packageLicense map[string]*Exception
+	packageLicense map[string][]*Exception
 	// packageAny maps "package" → Exception for packages exempted regardless of license.
-	packageAny map[string]*Exception
+	packageAny map[string][]*Exception
+	// ordered rules make suffix matching deterministic (file order).
+	packageRules []*Exception
 
 	Raw *ExceptionsFile
 }
@@ -60,17 +65,25 @@ func LoadExceptions(path string) (*ExceptionIndex, error) {
 		return nil, fmt.Errorf("failed to read exceptions file %s: %w", path, err)
 	}
 
-	var ef ExceptionsFile
-	if err := json.Unmarshal(data, &ef); err != nil {
+	var ef *ExceptionsFile
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&ef); err != nil {
 		return nil, fmt.Errorf("failed to parse exceptions file %s: %w", path, err)
 	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		return nil, fmt.Errorf("exceptions file %s must contain exactly one JSON object", path)
+	}
+	if ef == nil || ef.BlanketExceptions == nil || ef.Exceptions == nil {
+		return nil, fmt.Errorf("exceptions file %s must contain blanketExceptions and exceptions arrays (use [] for none)", path)
+	}
 
-	return BuildIndex(&ef), nil
+	return BuildIndex(ef), nil
 }
 
 // LoadExceptionsWithFallback tries the primary path first, then falls back to
-// additional paths. This allows the API Gateway to load exceptions from a
-// ConfigMap first, and fall back to a downloaded file in the SBOM PVC.
+// additional paths only when a file is absent. A valid empty file is authoritative;
+// an unreadable or invalid primary must never enable approvals from a fallback.
 func LoadExceptionsWithFallback(paths ...string) (*ExceptionIndex, error) {
 	var lastErr error
 	for _, p := range paths {
@@ -79,15 +92,13 @@ func LoadExceptionsWithFallback(paths ...string) (*ExceptionIndex, error) {
 		}
 		idx, err := LoadExceptions(p)
 		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return nil, err
+			}
 			lastErr = err
 			continue
 		}
-		// Return the first file that loads successfully and has actual content
-		if idx.Raw != nil && (len(idx.Raw.BlanketExceptions) > 0 || len(idx.Raw.Exceptions) > 0) {
-			return idx, nil
-		}
-		// File loaded but is empty, keep looking
-		lastErr = fmt.Errorf("exceptions file %s is empty", p)
+		return idx, nil
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("no valid exceptions file paths provided")
@@ -99,8 +110,8 @@ func LoadExceptionsWithFallback(paths ...string) (*ExceptionIndex, error) {
 func BuildIndex(ef *ExceptionsFile) *ExceptionIndex {
 	idx := &ExceptionIndex{
 		blanketLicenses: make(map[string]*BlanketException),
-		packageLicense:  make(map[string]*Exception),
-		packageAny:      make(map[string]*Exception),
+		packageLicense:  make(map[string][]*Exception),
+		packageAny:      make(map[string][]*Exception),
 		Raw:             ef,
 	}
 
@@ -119,30 +130,16 @@ func BuildIndex(ef *ExceptionsFile) *ExceptionIndex {
 			continue
 		}
 
-		// CNCF exceptions with "All CNCF Projects" are effectively blanket
-		// exceptions — they apply globally regardless of which SBOM uses them.
-		if strings.EqualFold(exc.Project, "All CNCF Projects") {
-			for _, lic := range splitLicenses(exc.License) {
-				// Promote to blanket exception so IsExempt matches any package.
-				idx.blanketLicenses[lic] = &BlanketException{
-					ID:           exc.ID,
-					License:      lic,
-					Status:       exc.Status,
-					ApprovedDate: exc.ApprovedDate,
-					Scope:        exc.Scope,
-					Comment:      exc.Comment,
-				}
-			}
-			continue
-		}
-
 		if exc.License != "" && exc.Package != "" {
 			for _, lic := range splitLicenses(exc.License) {
 				key := exc.Package + "\x00" + lic
-				idx.packageLicense[key] = exc
+				idx.packageLicense[key] = append(idx.packageLicense[key], exc)
 			}
 		} else if exc.Package != "" {
-			idx.packageAny[exc.Package] = exc
+			idx.packageAny[exc.Package] = append(idx.packageAny[exc.Package], exc)
+		}
+		if exc.Package != "" {
+			idx.packageRules = append(idx.packageRules, exc)
 		}
 	}
 
@@ -196,7 +193,8 @@ func splitLicenses(expr string) []string {
 
 // IsExempt checks if a package+license combination is covered by an exception.
 // Returns the matching exception reason or empty string if not exempt.
-func (idx *ExceptionIndex) IsExempt(packageName, licenseID string) (exempt bool, reason string) {
+// project is the SBOM document name. Omitting it never matches a scoped rule.
+func (idx *ExceptionIndex) IsExempt(packageName, licenseID string, project ...string) (exempt bool, reason string) {
 	if idx == nil {
 		return false, ""
 	}
@@ -208,44 +206,54 @@ func (idx *ExceptionIndex) IsExempt(packageName, licenseID string) (exempt bool,
 
 	// 1b. Check blanket license exceptions (prefix match for SPDX modifiers).
 	// e.g. "MPL-2.0-no-copyleft-exception" should match blanket "MPL-2.0".
-	for baseLicense, be := range idx.blanketLicenses {
-		if strings.HasPrefix(licenseID, baseLicense+"-") {
-			return true, fmt.Sprintf("Blanket exception: %s (via %s) – %s", be.ID, baseLicense, be.Comment)
+	// Prefer the longest matching base, independent of map iteration order.
+	for end := strings.LastIndex(licenseID, "-"); end > 0; end = strings.LastIndex(licenseID[:end], "-") {
+		if be, ok := idx.blanketLicenses[licenseID[:end]]; ok {
+			return true, fmt.Sprintf("Blanket exception: %s (via %s) – %s", be.ID, licenseID[:end], be.Comment)
 		}
 	}
 
 	// 2. Check specific package+license (exact match).
 	key := packageName + "\x00" + licenseID
-	if exc, ok := idx.packageLicense[key]; ok {
-		return true, fmt.Sprintf("Exception: %s – %s", exc.ID, exc.Comment)
-	}
-
-	// 2b. Check package+license with substring matching on package name.
-	// CNCF exceptions use short names like "cyphar/filepath-securejoin" but
-	// SBOM packages have full names like "github.com/cyphar/filepath-securejoin".
-	lowerPkg := strings.ToLower(packageName)
-	for compoundKey, exc := range idx.packageLicense {
-		parts := strings.SplitN(compoundKey, "\x00", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		excPkg, excLic := parts[0], parts[1]
-		if excLic == licenseID && strings.Contains(lowerPkg, strings.ToLower(excPkg)) {
+	for _, exc := range idx.packageLicense[key] {
+		if matchesProject(exc.Project, project) {
 			return true, fmt.Sprintf("Exception: %s – %s", exc.ID, exc.Comment)
 		}
 	}
 
-	// 3. Check package-only exceptions (any license, exact match).
-	if exc, ok := idx.packageAny[packageName]; ok {
-		return true, fmt.Sprintf("Exception: %s – %s", exc.ID, exc.Comment)
+	// 2b. Allow qualified names to match a complete path suffix, not arbitrary
+	// substrings (e.g. foo/bar must not exempt foo/bar-evil or notfoo/bar).
+	for _, exc := range idx.packageRules {
+		if !strings.HasSuffix(packageName, "/"+exc.Package) || !matchesProject(exc.Project, project) {
+			continue
+		}
+		for _, lic := range splitLicenses(exc.License) {
+			if lic == licenseID {
+				return true, fmt.Sprintf("Exception: %s – %s", exc.ID, exc.Comment)
+			}
+		}
 	}
 
-	// 3b. Package-only exceptions with substring matching.
-	for excPkg, exc := range idx.packageAny {
-		if strings.Contains(lowerPkg, strings.ToLower(excPkg)) {
+	// 3. Check package-only exceptions (any license, exact match).
+	for _, exc := range idx.packageAny[packageName] {
+		if matchesProject(exc.Project, project) {
+			return true, fmt.Sprintf("Exception: %s – %s", exc.ID, exc.Comment)
+		}
+	}
+
+	// 3b. Package-only exceptions with path-segment suffix matching.
+	for _, exc := range idx.packageRules {
+		if exc.License == "" && strings.HasSuffix(packageName, "/"+exc.Package) && matchesProject(exc.Project, project) {
 			return true, fmt.Sprintf("Exception: %s – %s", exc.ID, exc.Comment)
 		}
 	}
 
 	return false, ""
+}
+
+func matchesProject(scope string, projects []string) bool {
+	if scope == "" || scope == "*" || scope == "All Projects" {
+		return true
+	}
+	return len(projects) > 0 && scope == projects[0]
 }

--- a/backend/internal/license/exceptions_test.go
+++ b/backend/internal/license/exceptions_test.go
@@ -1,0 +1,164 @@
+package license
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExceptionsPrimaryIsAuthoritative(t *testing.T) {
+	for _, tt := range []struct {
+		name, primary string
+		wantError     bool
+	}{
+		{"empty", `{"blanketExceptions":[],"exceptions":[]}`, false},
+		{"revoked", `{"blanketExceptions":[{"id":"old","license":"MPL-2.0","status":"revoked"}],"exceptions":[]}`, false},
+		{"invalid JSON", `{`, true},
+		{"null", `null`, true},
+		{"missing arrays", `{}`, true},
+		{"null array", `{"blanketExceptions":null,"exceptions":[]}`, true},
+		{"wrong array type", `{"blanketExceptions":{},"exceptions":[]}`, true},
+		{"unknown rule field", `{"blanketExceptions":[],"exceptions":[{"purl_prefix":"pkg:golang/example.org/lib","status":"approved"}]}`, true},
+		{"multiple documents", `{"blanketExceptions":[],"exceptions":[]} {}`, true},
+		{"trailing garbage", `{"blanketExceptions":[],"exceptions":[]} invalid`, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			primary, fallback := filepath.Join(dir, "primary.json"), filepath.Join(dir, "fallback.json")
+			for path, content := range map[string]string{
+				primary:  tt.primary,
+				fallback: `{"blanketExceptions":[{"id":"stale","license":"MPL-2.0","status":"approved"}],"exceptions":[]}`,
+			} {
+				if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			idx, err := LoadExceptionsWithFallback(primary, fallback)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("error = %v, wantError = %v", err, tt.wantError)
+			}
+			if exempt, reason := idx.IsExempt("any-package", "MPL-2.0"); exempt {
+				t.Fatalf("fallback must not enable stale approval: %s", reason)
+			}
+		})
+	}
+}
+
+func TestExceptionsUnreadablePrimaryDoesNotFallBack(t *testing.T) {
+	dir := t.TempDir()
+	fallback := filepath.Join(dir, "fallback.json")
+	if err := os.WriteFile(fallback, []byte(`{"blanketExceptions":[],"exceptions":[]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Reading a directory as a file fails even when the tests run as root.
+	if _, err := LoadExceptionsWithFallback(dir, fallback); err == nil {
+		t.Fatal("expected primary read error, not fallback success")
+	}
+}
+
+func TestExceptionProjectAndPackageBoundaries(t *testing.T) {
+	for _, lic := range []string{"MPL-2.0", ""} {
+		t.Run("license="+lic, func(t *testing.T) {
+			idx := BuildIndex(&ExceptionsFile{Exceptions: []Exception{
+				{ID: "alpha", Package: "team/library", License: lic, Project: "alpha", Status: "approved"},
+				{ID: "beta", Package: "team/library", License: lic, Project: "beta", Status: "approved"},
+				{ID: "revoked", Package: "team/library", License: lic, Project: "gamma", Status: "revoked"},
+			}})
+			for _, tt := range []struct {
+				pkg, project, reason string
+			}{
+				{"team/library", "alpha", "alpha"},
+				{"team/library", "beta", "beta"},
+				{"example.org/team/library", "alpha", "alpha"},
+				{"example.org/team/library", "beta", "beta"},
+				{"team/library", "gamma", ""},
+				{"team/library", "", ""},
+				{"team/library", "Alpha", ""},
+				{"example.org/team/library-evil", "alpha", ""},
+				{"example.org/notteam/library", "alpha", ""},
+				{"example.org/team/library/submodule", "alpha", ""},
+				{"example.org/TEAM/library", "alpha", ""},
+				{"", "alpha", ""},
+			} {
+				exempt, reason := idx.IsExempt(tt.pkg, "MPL-2.0", tt.project)
+				if exempt != (tt.reason != "") || (exempt && !strings.Contains(reason, "Exception: "+tt.reason+" ")) {
+					t.Errorf("IsExempt(%q, project=%q) = %v, %q; want %q", tt.pkg, tt.project, exempt, reason, tt.reason)
+				}
+			}
+		})
+	}
+}
+
+func TestExceptionGlobalProjectDoesNotMeanBlanket(t *testing.T) {
+	for _, scope := range []string{"", "*", "All Projects", "All CNCF Projects"} {
+		idx := BuildIndex(&ExceptionsFile{Exceptions: []Exception{
+			{ID: "package-only", Package: "library", License: "MPL-2.0", Project: scope, Status: "approved"},
+		}})
+		if exempt, _ := idx.IsExempt("unrelated", "MPL-2.0", scope); exempt {
+			t.Errorf("scope %q promoted a package exception to blanket", scope)
+		}
+		got, _ := idx.IsExempt("library", "MPL-2.0", "my-project")
+		if got != (scope != "All CNCF Projects") {
+			t.Errorf("scope %q: exempt=%v", scope, got)
+		}
+	}
+}
+
+func TestCheckWithExceptionsProjectContext(t *testing.T) {
+	idx := BuildIndex(&ExceptionsFile{Exceptions: []Exception{
+		{ID: "only-alpha", Package: "library", License: "MPL-2.0", Project: "alpha", Status: "approved"},
+	}})
+	for _, project := range []string{"alpha", "beta", ""} {
+		results := CheckWithExceptions([]string{"library"}, []string{"MPL-2.0"}, idx, project)
+		if len(results) != 1 {
+			t.Fatalf("expected one result, got %v", results)
+		}
+		if (len(results[0].ExemptedPackages) == 1) != (project == "alpha") ||
+			(len(results[0].NonCompliantPackages) == 1) != (project != "alpha") {
+			t.Errorf("project %q: unexpected result %+v", project, results[0])
+		}
+	}
+}
+
+func TestExceptionDefaultsAndExampleHaveNoApprovals(t *testing.T) {
+	for _, path := range []string{
+		"../../../sboms/license-exceptions.json",
+		"../../../examples/license-exceptions/license-exceptions.example.json",
+	} {
+		idx, err := LoadExceptions(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(idx.blanketLicenses) != 0 || len(idx.packageLicense) != 0 || len(idx.packageAny) != 0 {
+			t.Errorf("%s contains active approvals", path)
+		}
+	}
+}
+
+func TestExceptionMatchOrderIsDeterministic(t *testing.T) {
+	idx := BuildIndex(&ExceptionsFile{
+		BlanketExceptions: []BlanketException{
+			{ID: "short", License: "LicenseRef", Status: "approved"},
+			{ID: "long", License: "LicenseRef-team", Status: "approved"},
+		},
+		Exceptions: []Exception{
+			{ID: "first", Package: "team/lib", License: "MPL-2.0", Status: "approved"},
+			{ID: "second", Package: "team/lib", License: "MPL-2.0", Status: "approved"},
+			{ID: "exact", Package: "example.org/team/lib", License: "MPL-2.0", Status: "approved"},
+		},
+	})
+	for i := 0; i < 50; i++ {
+		for _, tt := range []struct{ pkg, lic, reason string }{
+			{"pkg", "LicenseRef-team-special", "Blanket exception: long "},
+			{"team/lib", "MPL-2.0", "Exception: first "},
+			{"other.org/team/lib", "MPL-2.0", "Exception: first "},
+			{"example.org/team/lib", "MPL-2.0", "Exception: exact "},
+		} {
+			exempt, reason := idx.IsExempt(tt.pkg, tt.lic)
+			if !exempt || !strings.HasPrefix(reason, tt.reason) {
+				t.Fatalf("IsExempt(%q, %q) = %v, %q; want %q", tt.pkg, tt.lic, exempt, reason, tt.reason)
+			}
+		}
+	}
+}

--- a/deploy/helm/bomhort/templates/configmap-license-exceptions.yaml
+++ b/deploy/helm/bomhort/templates/configmap-license-exceptions.yaml
@@ -1,4 +1,18 @@
 {{- if .Values.licenseExceptions.enabled }}
+{{- $exceptions := dict "version" "1.0.0" "description" "No exceptions configured. Supply organization-approved rules explicitly." "blanketExceptions" (list) "exceptions" (list) }}
+{{- if not (and (kindIs "string" .Values.licenseExceptions.custom) (eq .Values.licenseExceptions.custom "")) }}
+{{- if kindIs "string" .Values.licenseExceptions.custom }}
+{{- $exceptions = mustFromJson .Values.licenseExceptions.custom }}
+{{- else }}
+{{- $exceptions = .Values.licenseExceptions.custom }}
+{{- end }}
+{{- end }}
+{{- if not (kindIs "map" $exceptions) }}
+{{- fail "licenseExceptions.custom must be an object (YAML mapping or JSON string)" }}
+{{- end }}
+{{- if or (not (kindIs "slice" $exceptions.blanketExceptions)) (not (kindIs "slice" $exceptions.exceptions)) }}
+{{- fail "licenseExceptions.custom must contain blanketExceptions and exceptions arrays (use [] for none)" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,12 +22,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
   license-exceptions.json: |-
-    {
-      "version": "1.0.0",
-      "lastUpdated": "2026-03-07",
-      "description": "License exceptions for BOMHort. Edit this ConfigMap to add/remove exceptions.",
-      "blanketExceptions": [],
-      "exceptions": []
-    }
+    {{- $exceptions | mustToPrettyJson | nindent 4 }}
 {{- end }}
 

--- a/deploy/helm/bomhort/templates/deployment-api-gateway.yaml
+++ b/deploy/helm/bomhort/templates/deployment-api-gateway.yaml
@@ -14,6 +14,10 @@ spec:
       app.kubernetes.io/component: api-gateway
   template:
     metadata:
+      {{- if .Values.licenseExceptions.enabled }}
+      annotations:
+        checksum/license-exceptions: {{ include (print $.Template.BasePath "/configmap-license-exceptions.yaml") . | sha256sum }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: bomhort
         app.kubernetes.io/component: api-gateway

--- a/deploy/helm/bomhort/templates/deployment-parsing-worker.yaml
+++ b/deploy/helm/bomhort/templates/deployment-parsing-worker.yaml
@@ -14,6 +14,10 @@ spec:
       app.kubernetes.io/component: parsing-worker
   template:
     metadata:
+      {{- if .Values.licenseExceptions.enabled }}
+      annotations:
+        checksum/license-exceptions: {{ include (print $.Template.BasePath "/configmap-license-exceptions.yaml") . | sha256sum }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: bomhort
         app.kubernetes.io/component: parsing-worker

--- a/deploy/helm/bomhort/templates/job-seed-sboms.yaml
+++ b/deploy/helm/bomhort/templates/job-seed-sboms.yaml
@@ -1,3 +1,6 @@
+{{- if .Values.seedJob.cncfExceptionsURL }}
+{{- fail "seedJob.cncfExceptionsURL is no longer supported: remove it and provide reviewed rules via licenseExceptions.custom or --set-file licenseExceptions.custom=./my-exceptions.json" }}
+{{- end }}
 {{- if not .Values.gitSync.enabled }}
 apiVersion: batch/v1
 kind: Job
@@ -60,14 +63,6 @@ spec:
                 echo "⏳ Waiting for SBOMs to be ready..."
                 sleep 30
               done
-              {{- if .Values.seedJob.cncfExceptionsURL }}
-              echo "⏳ Downloading CNCF license exceptions..."
-              if curl -sSL "{{ .Values.seedJob.cncfExceptionsURL }}" -o "$TARGET/license-exceptions.json"; then
-                echo "  ✅ license-exceptions.json downloaded"
-              else
-                echo "  ⚠️ Failed to download exceptions (non-fatal)"
-              fi
-              {{- end }}
 
               echo "✅ Seed complete: $SBOM_COUNT SBOMs, $VEX_COUNT VEX docs"
           volumeMounts:

--- a/deploy/helm/bomhort/values.yaml
+++ b/deploy/helm/bomhort/values.yaml
@@ -107,10 +107,15 @@ gitSync:
   # For private repos, mount a Secret with SSH key or token:
   # secretName: git-sync-credentials
 
-# License exceptions (mounted as ConfigMap, read-only)
+# License exceptions (mounted as ConfigMap, read-only). No approvals by default.
 licenseExceptions:
   enabled: true
   mountPath: /data/config/license-exceptions.json
+  # YAML object or JSON string; both blanketExceptions and exceptions must be arrays.
+  # Alternatively: --set-file licenseExceptions.custom=./my-exceptions.json
+  # See examples/license-exceptions/ for an inactive example to adapt and review.
+  # Changes trigger API/worker rollouts; re-process SBOMs to update stored results.
+  custom: ""
 
 # License policy – defines permissive/copyleft classification (ConfigMap, read-only)
 licensePolicy:
@@ -262,8 +267,7 @@ cveRefresher:
 seedJob:
   sbomRepo: "https://github.com/cncf/sbom.git"
   sbomBranch: main
-  # Set to download CNCF license exceptions into the SBOM PVC:
-  # cncfExceptionsURL: "https://raw.githubusercontent.com/cncf/foundation/main/license-exceptions/exceptions.json"
+  # License exceptions are configured via licenseExceptions.custom, not downloaded.
 
 # Data Migration (one-time, from old seebom deployment to new bomhort deployment)
 # Runs as a Helm post-upgrade hook. Uses ClickHouse remote() to copy all tables

--- a/deploy/helm/tests/test_license_exceptions.py
+++ b/deploy/helm/tests/test_license_exceptions.py
@@ -1,0 +1,125 @@
+"""Run with python3 -m unittest discover -s deploy/helm/tests -v (requires helm)."""
+
+import json
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CHART = ROOT / "deploy/helm/bomhort"
+
+
+class LicenseExceptionsTemplatesTest(unittest.TestCase):
+    def render(self, values=None, args=(), success=True):
+        with tempfile.TemporaryDirectory() as directory:
+            values_file = Path(directory) / "values.json"
+            values_file.write_text(json.dumps(values or {}))
+            result = subprocess.run(
+                ["helm", "template", "test", str(CHART), "-f", str(values_file), *args],
+                cwd=ROOT, text=True, capture_output=True, check=False,
+            )
+        if success:
+            self.assertEqual(result.returncode, 0, result.stderr)
+        else:
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+        return result.stdout if success else result.stderr
+
+    def exceptions(self, rendered):
+        match = re.search(r"^  license-exceptions\.json: \|-\n((?:    .*\n|\n)+)", rendered, re.MULTILINE)
+        self.assertIsNotNone(match, rendered)
+        return json.loads(textwrap.dedent(match.group(1)))
+
+    def checksums(self, rendered):
+        result = {}
+        for component in ("api-gateway", "parsing-worker"):
+            match = re.search(
+                rf"# Source: bomhort/templates/deployment-{component}\.yaml\n(.*?)(?=\n---|\Z)",
+                rendered, re.DOTALL,
+            )
+            self.assertIsNotNone(match)
+            checksum = re.search(r"checksum/license-exceptions: ([0-9a-f]{64})", match.group(1))
+            self.assertIsNotNone(checksum)
+            result[component] = checksum.group(1)
+        self.assertEqual(result["api-gateway"], result["parsing-worker"])
+        return result
+
+    def test_defaults_and_deployment_examples_are_empty(self):
+        for filename in (None, "examples/kind/values-kind.yaml",
+                         "examples/kubernetes/values-production.yaml",
+                         "examples/kubernetes/values-minimal.yaml"):
+            with self.subTest(filename=filename):
+                output = self.render(args=("-f", str(ROOT / filename)) if filename else ())
+                config = self.exceptions(output)
+                self.assertEqual(config["blanketExceptions"], [])
+                self.assertEqual(config["exceptions"], [])
+                self.assertNotIn("Downloading CNCF license exceptions", output)
+                self.checksums(output)
+
+    def test_mapping_json_string_and_set_file(self):
+        config = {
+            "version": "1.0.0", "blanketExceptions": [], "exceptions": [
+                {"id": "own-rule", "package": "example.org/team/lib", "license": "MPL-2.0",
+                 "project": "my-sbom", "status": "approved", "comment": 'Quotes " and {{ literal }}'}
+            ],
+        }
+        outputs = []
+        for custom in (config, json.dumps(config)):
+            output = self.render({"licenseExceptions": {"custom": custom}})
+            self.assertEqual(self.exceptions(output), config)
+            outputs.append(self.checksums(output))
+        with tempfile.TemporaryDirectory() as directory:
+            filename = Path(directory) / "exceptions.json"
+            filename.write_text(json.dumps(config))
+            output = self.render(args=("--set-file", f"licenseExceptions.custom={filename}"))
+            self.assertEqual(self.exceptions(output), config)
+            outputs.append(self.checksums(output))
+        self.assertEqual(outputs[0], outputs[1])
+        self.assertEqual(outputs[0], outputs[2])
+        self.assertNotEqual(outputs[0], self.checksums(self.render()))
+
+    def test_explicit_empty_and_revocation_change_both_rollouts(self):
+        config = {"blanketExceptions": [], "exceptions": [
+            {"id": "own-rule", "package": "lib", "license": "MPL-2.0", "status": "approved"}
+        ]}
+        approved = self.checksums(self.render({"licenseExceptions": {"custom": config}}))
+        config["exceptions"][0]["status"] = "revoked"
+        revoked = self.checksums(self.render({"licenseExceptions": {"custom": config}}))
+        config["exceptions"] = []
+        empty_output = self.render({"licenseExceptions": {"custom": config}})
+        self.assertEqual(self.exceptions(empty_output), config)
+        empty = self.checksums(empty_output)
+        for component in approved:
+            self.assertNotEqual(approved[component], revoked[component])
+            self.assertNotEqual(revoked[component], empty[component])
+
+    def test_disabled_removes_configmap_checksum_and_mounts(self):
+        output = self.render({"licenseExceptions": {"enabled": False}})
+        self.assertNotIn("configmap-license-exceptions.yaml", output)
+        self.assertNotIn("checksum/license-exceptions", output)
+        self.assertNotIn("name: license-exceptions", output)
+
+    def test_custom_mount_path_matches_environment(self):
+        output = self.render({"licenseExceptions": {"mountPath": "/custom/exceptions.json"}})
+        self.assertIn('EXCEPTIONS_FILE: "/custom/exceptions.json"', output)
+        self.assertEqual(output.count("mountPath: /custom/exceptions.json"), 2)
+        self.assertEqual(output.count("subPath: license-exceptions.json"), 2)
+
+    def test_invalid_custom_config_is_rejected(self):
+        for custom in ("{", "null", "[]", "{}", "42", {}, [], 0, False, {"exceptions": []},
+                       {"exceptions": [], "blanketExceptions": None},
+                       {"exceptions": "wrong", "blanketExceptions": []}):
+            with self.subTest(custom=custom):
+                error = self.render({"licenseExceptions": {"custom": custom}}, success=False)
+                self.assertRegex(error, r"licenseExceptions\.custom|mustFromJson")
+
+    def test_legacy_download_setting_requires_explicit_migration(self):
+        error = self.render({"seedJob": {"cncfExceptionsURL": "https://example.org/exceptions.json"}}, success=False)
+        self.assertIn("licenseExceptions.custom", error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/ARCHITECTURE_PLAN.md
+++ b/docs/ARCHITECTURE_PLAN.md
@@ -88,7 +88,7 @@ bomhort/
 │   └── migrations/            # 001-012 SQL migrations
 ├── sboms/                     # Config files + example SBOMs/VEX
 │   ├── license-policy.json        # Permissive/copyleft classification
-│   ├── license-exceptions.json    # CNCF-format exceptions
+│   ├── license-exceptions.json    # Organization-managed exceptions; empty by default
 │   ├── _example.spdx.json
 │   ├── _example.openvex.json
 │   ├── golang-common.openvex.json
@@ -325,7 +325,11 @@ Moved to Section 10 for comprehensive coverage including exemptions and visual r
 
 **License Policy** (`license-policy.json`): Defines which SPDX IDs are permissive/copyleft. Read by API Gateway and workers. Anything not listed = `unknown`.
 
-**License Exceptions** (`license-exceptions.json`): CNCF format with blanket and specific exceptions. Blanket exceptions support prefix matching (e.g. `MPL-2.0` matches `MPL-2.0-no-copyleft-exception`). Written at ingest time into `exempted_packages` + `exemption_reason` columns and considered at query time in the dashboard. Read-only — no write API (frontend is public).
+**License Exceptions** (`license-exceptions.json`): Operator-managed blanket and package/license/project rules, empty by default. No automatic CNCF download or project-to-blanket promotion. An inactive structure example lives in `examples/license-exceptions/`. Blanket exceptions retain SPDX modifier-prefix matching (e.g. `MPL-2.0` matches `MPL-2.0-no-copyleft-exception`). Package rules match case-sensitive exact names or complete slash-delimited suffixes; optional project restrictions use the exact SBOM document name in both worker and API filtering. Multiple project rules are preserved and matching order is deterministic. Scope descriptions and dates remain audit metadata, not executable conditions.
+
+The first existing exception file is authoritative, even when empty. Fallback to the SBOM directory occurs only when the primary is missing. Unknown JSON fields, malformed structure, and read errors are surfaced (worker startup failure / exception-related API HTTP 500), not silently replaced by another list. Helm `licenseExceptions.custom` accepts a YAML object or JSON string and validates the two required arrays. ConfigMap checksums roll out API and worker pods together to refresh their `subPath` mounts; no live ConfigMap watch is assumed.
+
+Exemptions are written at ingest time into `exempted_packages` + `exemption_reason` columns and considered at query time. Existing SBOMs must be re-processed after changes: filtering stored violations cannot restore previously exempted packages after revocation. A watcher run alone does not bypass hash deduplication. Read-only — no write API (frontend is public), no schema changes or automatic data resets.
 
 **Permissive Licenses:** Packages with permissive licenses (MIT, Apache-2.0, BSD) are **never** tracked as non-compliant.
 
@@ -337,6 +341,7 @@ Moved to Section 10 for comprehensive coverage including exemptions and visual r
 **Configuration:**
 - Local: JSON files in `sboms/`, mounted via Docker Compose
 - K8s: ConfigMaps (`bomhort-license-policy`, `bomhort-license-exceptions`)
+- Argo CD: Git-backed `helm.valueFiles` or `helm.valuesObject` supplies `licenseExceptions.custom`. Rendering changes the exception ConfigMap and the deterministic `checksum/license-exceptions` annotation on both Deployment pod templates. Sync applies these resources and triggers Kubernetes rollouts without a Helm upgrade hook. Chart and API/worker images must contain the fixes; syncing does not re-process stored SBOMs. See the [Argo CD deployment checklist](content/docs/deployment/_index.md#argo-cd-gitops).
 
 ## 10a. GitHub Dependency Health
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -98,7 +98,6 @@ gitSync:
 seedJob:
   sbomRepo: "https://github.com/cncf/sbom.git"
   sbomBranch: main
-  cncfExceptionsURL: "https://raw.githubusercontent.com/cncf/foundation/main/license-exceptions/exceptions.json"
 
 sbomSource:
   storageSize: 20Gi
@@ -170,51 +169,73 @@ Files are **deduplicated by SHA256 hash** — uploading the same file twice will
 
 License exceptions suppress specific license violations. They are stored in a **ConfigMap** that is mounted read-only into the API Gateway and Workers.
 
-### Edit the default ConfigMap
+### Configure reviewed exceptions through Helm
 
-After `helm install`, edit the ConfigMap directly:
-
-```bash
-kubectl edit configmap bomhort-license-exceptions
-```
-
-The JSON format follows the [CNCF exceptions format](https://github.com/cncf/foundation/blob/main/license-exceptions/exceptions.json):
-
-```json
-{
-  "version": "1.0.0",
-  "lastUpdated": "2026-03-07",
-  "blanketExceptions": [
-    {
-      "id": "blanket-mpl-2.0",
-      "license": "MPL-2.0",
-      "status": "approved",
-      "approvedDate": "2026-03-07",
-      "comment": "MPL-2.0 is file-level copyleft, acceptable for unmodified deps."
-    }
-  ],
-  "exceptions": [
-    {
-      "id": "exc-001",
-      "package": "github.com/hashicorp/golang-lru",
-      "license": "MPL-2.0",
-      "status": "approved",
-      "approvedDate": "2026-03-07",
-      "comment": "Widely used LRU cache, unmodified."
-    }
-  ]
-}
-```
-
-### Apply changes
-
-After editing, restart the API Gateway to pick up changes:
+The default list is **empty**. No CNCF approvals are downloaded or implied.
+Use the [inactive example and migration guide](../examples/license-exceptions/README.md)
+as a structure to adapt, not as pre-approved policy.
 
 ```bash
-kubectl rollout restart deployment bomhort-api-gateway
+helm upgrade --install bomhort deploy/helm/bomhort -n bomhort \
+  -f my-values.yaml --set-file licenseExceptions.custom=./my-exceptions.json
 ```
 
-> **Note:** Violations are filtered at query time, so no re-ingestion is needed.
+Alternatively, supply a YAML object in your values. To explicitly disable all approvals:
+
+```yaml
+licenseExceptions:
+  enabled: true
+  custom:
+    version: "1.0.0"
+    blanketExceptions: []
+    exceptions: []
+```
+
+Both arrays are required. An empty file is authoritative; only a missing file
+permits fallback to `SBOM_DIR/license-exceptions.json`. Malformed configuration
+stops the worker and causes exception-related API requests to return HTTP 500.
+`enabled: false` disables only the Helm mount, not the legacy file fallback.
+
+Only rules with `status: "approved"` apply. Package rules match exact names or
+complete slash-delimited suffixes. `project` is the exact SBOM document name;
+empty or `"*"` means all projects. It never turns a package rule into a blanket
+rule. Use `blanketExceptions` only for genuinely organization-wide approvals.
+`scope` and dates are informational, not executable conditions.
+
+### Apply changes and migrate
+
+Helm checksums trigger rollouts of **both** API Gateway and workers when the
+exception ConfigMap changes. For emergency direct ConfigMap edits, restart both
+deployments manually; subsequent Helm upgrades overwrite such edits.
+
+Remove the former `seedJob.cncfExceptionsURL` setting from existing values;
+the chart rejects it with instructions to use `licenseExceptions.custom` instead.
+Review old `"All CNCF Projects"` rules explicitly: that value now has only literal
+project-name semantics, not global approval semantics.
+
+**Re-process existing SBOMs** after changing exceptions, particularly removals.
+Query-time filtering alone cannot recover previously exempted packages from stored
+results, and the watcher skips unchanged hashes. Back up data and plan a re-scan;
+development full-reset helpers are destructive and are not a production
+license-only refresh mechanism.
+
+### Argo CD (GitOps)
+
+Store `licenseExceptions.custom` in Git-backed Helm values referenced by your
+Application's `helm.valueFiles` or `helm.valuesObject`. For multi-source
+Applications, configure the entry that renders the Helm chart.
+See the [Argo CD example and deployment checklist](content/docs/deployment/_index.md#argo-cd-gitops).
+
+Argo only needs to render and sync the chart: changed exceptions alter the
+ConfigMap and checksum annotations on both API and worker pod templates, so
+Kubernetes rolls out both Deployments during sync. No Helm upgrade hook or manual
+restart is required. Sync all affected resources and keep edits in Git rather
+than modifying the live ConfigMap.
+
+Deploy a chart revision and API/worker images that include the fixes, and remove
+`seedJob.cncfExceptionsURL` from all Argo values/parameters. A successful Argo sync
+does **not** re-process existing SBOMs; plan that separately to refresh stored
+compliance results after changing or revoking approvals.
 
 ---
 
@@ -586,7 +607,7 @@ ingress:
 | **SBOMs (S3)** | S3-compatible buckets | Configure `s3.buckets` in Helm values, CronJob streams objects |
 | **SBOMs (volume)** | PVC via seed job or git-sync | Push to Git, seed job clones or git-sync re-syncs |
 | **VEX files** | Same S3 bucket or directory as SBOMs | Place `*.openvex.json` or `*.vex.json` alongside SBOMs |
-| **License Exceptions** | `bomhort-license-exceptions` ConfigMap | `kubectl edit configmap` → restart API |
+| **License Exceptions** | `bomhort-license-exceptions` ConfigMap | `licenseExceptions.custom` → Helm rollout of API + workers → re-process existing SBOMs |
 | **License Policy** | `bomhort-license-policy` ConfigMap | `kubectl edit configmap` → restart API + Workers |
 | **Custom Theme** | `bomhort-custom-theme` ConfigMap | `kubectl create configmap` → restart UI |
 | **Site Config** | `bomhort-ui-config` ConfigMap | Helm values `ui.siteConfig.content.*` → restart UI |

--- a/docs/content/docs/api-reference/_index.md
+++ b/docs/content/docs/api-reference/_index.md
@@ -655,27 +655,39 @@ Projects with copyleft or unknown license packages (filtered by active exception
 
 ### `GET /api/v1/license-exceptions`
 
-Active license exceptions (read-only, loaded from config file).
+Configured license exception document (read-only, loaded from config file).
+Includes pending/revoked rules for inspection; only `approved` rules affect checks.
+By default both arrays are empty. No CNCF approvals are automatically loaded.
 
 **Response:** `200 OK`
 ```json
 {
   "version": "1.0.0",
-  "blanket_exceptions": [
-    {
-      "license": "ISC",
-      "reason": "ISC is functionally equivalent to MIT"
-    }
-  ],
+  "lastUpdated": "",
+  "blanketExceptions": [],
   "exceptions": [
     {
-      "purl_prefix": "pkg:golang/github.com/some/gpl-lib",
-      "license": "GPL-2.0-only",
-      "reason": "Build tool only, not distributed with binary"
+      "id": "example-review-required",
+      "package": "example.org/team/library",
+      "license": "MPL-2.0",
+      "project": "my-sbom-document-name",
+      "status": "pending",
+      "approvedDate": "",
+      "comment": "Example only; requires organization approval"
     }
   ]
 }
 ```
+
+Field names are **camelCase**, and `package` is a package name, not a PURL prefix
+or glob. A package rule retains its package restriction even when `project` is
+empty or `"*"`. Otherwise `project` matches the exact SBOM document name.
+
+**Configuration errors:** `500 Internal Server Error` for malformed or unreadable
+exception files (also on `GET /api/v1/projects/license-compliance`). Missing optional
+files return an empty document. An existing empty primary file takes precedence
+over any fallback file. Configuration changes require re-processing existing SBOMs
+for stored compliance results to become consistent across endpoints.
 
 ### `GET /api/v1/license-policy`
 

--- a/docs/content/docs/architecture/_index.md
+++ b/docs/content/docs/architecture/_index.md
@@ -186,7 +186,8 @@ Lightweight daily CronJob that queries all unique PURLs (~20k) against the OSV A
 ## License Governance
 
 - **License Policy** (`license-policy.json`): Defines permissive vs. copyleft classifications
-- **License Exceptions** (`license-exceptions.json`): CNCF format, blanket + specific
+- **License Exceptions** (`license-exceptions.json`): Empty by default; explicit organization-managed blanket or package/license/project rules. No CNCF download or implicit global approval. Configure through `licenseExceptions.custom`; Helm rolls out API and workers on changes. Existing SBOMs must be re-processed to update stored compliance results.
+- **Argo CD / GitOps:** Git-backed Helm values update the exception ConfigMap and deterministic checksums on both Deployment pod templates. Argo sync triggers Kubernetes rollouts without Helm upgrade hooks; it does not re-process existing SBOMs. Deploy matching chart and API/worker image revisions. See [Argo CD deployment](../deployment/#argo-cd-gitops).
 - **Permissive licenses** (MIT, Apache-2.0, BSD) are **never** tracked as non-compliant
 - **Visual:** Green = exempted copyleft, Red = violation, Orange = exempted in dependency tree
 

--- a/docs/content/docs/deployment/_index.md
+++ b/docs/content/docs/deployment/_index.md
@@ -226,10 +226,123 @@ apiGateway:
 
 License exceptions suppress specific license violations. They are stored in a **ConfigMap** that is mounted read-only into the API Gateway and Workers.
 
+**No exceptions are enabled or downloaded by default.** Adapt the inactive
+`examples/license-exceptions/license-exceptions.example.json` structure to your
+organization and approve only reviewed rules. Configure it with your normal values:
+
 ```bash
-kubectl edit configmap bomhort-license-exceptions
-kubectl rollout restart deployment bomhort-api-gateway
+helm upgrade --install bomhort deploy/helm/bomhort -n bomhort \
+  -f my-values.yaml --set-file licenseExceptions.custom=./my-exceptions.json
 ```
+
+`licenseExceptions.custom` also accepts a YAML object. An explicit empty template is:
+
+```yaml
+licenseExceptions:
+  enabled: true
+  custom:
+    version: "1.0.0"
+    blanketExceptions: []
+    exceptions: []
+```
+
+Use camelCase `blanketExceptions` and `package` (not `blanket_exceptions` or
+`purl_prefix`). Both arrays are required. Only `status: "approved"` activates a
+rule. Package names match exactly or as complete slash-delimited suffixes;
+`project` is an exact SBOM document name (omit it or use `"*"` for all projects).
+There is no CNCF-specific blanket promotion. Audit fields such as `scope` and
+dates are informational, not automatically enforced conditions.
+
+Empty lists are authoritative and never load old approvals from the SBOM directory.
+Fallback is allowed only when the primary file is absent. Invalid configuration
+stops the worker and returns HTTP 500 from exception-related API endpoints.
+Keep the ConfigMap enabled with empty lists to disable approvals; disabling the
+mount alone does not disable the legacy SBOM-directory fallback.
+
+Helm changes restart **both** API and workers via checksums. Direct ConfigMap
+edits require manually restarting both deployments because of `subPath` mounts.
+**Re-process existing SBOMs** to update stored compliance data, especially after
+revoking approvals; a watcher run alone skips unchanged hashes. Back up data
+before a full re-scan; development reset helpers delete ingested data.
+
+For upgrades, remove `seedJob.cncfExceptionsURL` (also from retained Helm values)
+and supply reviewed rules explicitly. `"All CNCF Projects"` is now a literal
+project name, not a global approval. The default license classification policy
+is unchanged.
+
+### Argo CD (GitOps)
+
+License exception updates also work when Argo CD renders the chart with
+`helm template`: the rollout mechanism does **not** depend on running
+`helm upgrade` or on a Helm upgrade hook.
+
+Keep exceptions in your GitOps repository, either in a Helm values file referenced
+by `spec.source.helm.valueFiles` or directly in `spec.source.helm.valuesObject`.
+The following is a **fragment to merge into your existing Application**, not a
+complete deployment manifest. For multi-source Applications, use the Helm chart
+entry under `spec.sources[]` instead of `spec.source`.
+
+```yaml
+spec:
+  source:
+    helm:
+      valuesObject:
+        licenseExceptions:
+          enabled: true
+          custom:
+            version: "1.0.0"
+            blanketExceptions: []
+            exceptions:
+              - id: example-review-required
+                package: example.org/your-team/your-library
+                license: MPL-2.0
+                project: your-exact-sbom-document-name
+                status: pending
+                approvedDate: ""
+                comment: "Example only; requires organization approval."
+```
+
+This example grants **no approval**. Replace the placeholders, review the rule,
+then explicitly set `status: approved` only after approval. To remove all
+approvals, keep `enabled: true` and set both arrays to `[]`.
+
+If your Argo CD Application CRD does not support `valuesObject`, use a committed
+values file or the equivalent YAML in `helm.values`. Do not rely on a workstation's
+local `--set-file` invocation: Argo must receive the configuration through its own
+Git-backed Helm inputs. Avoid defining the same exceptions in multiple layers;
+`valuesObject` overrides `valueFiles`, and Helm `parameters` override both.
+
+**What happens on a change:**
+
+1. Commit the reviewed values and let Argo refresh the desired manifests.
+2. The rendered ConfigMap data changes, together with
+   `spec.template.metadata.annotations.checksum/license-exceptions` on **both**
+   the API Gateway and parsing-worker Deployments. Checksums are deterministic:
+   unchanged configuration does not cause repeated rollouts.
+3. At the next sync (manual or automated according to your Application policy),
+   Argo applies the ConfigMap and both Deployment changes. Kubernetes rolls out
+   new pods, refreshing the read-only `subPath` mounts. No manual restart is needed.
+
+**Deployment checklist:**
+
+- Point Argo at a chart revision **and API/worker image versions containing these
+  fixes**. Updating only the chart does not update the matching/loading behavior
+  in older binaries. Local, unpushed changes are not available to Argo.
+- Remove `seedJob.cncfExceptionsURL` from all GitOps values and parameter overrides;
+  the chart rejects this retired option with a migration hint.
+- For an exception-only change, check the Argo diff for the ConfigMap and both
+  Deployment checksum annotations. Sync all affected resources, not just the
+  ConfigMap, and do not configure diff/sync rules that suppress the checksum changes.
+- Wait for both Deployments to become healthy. Verify the configured rules through
+  `GET /api/v1/license-exceptions` or the UI's **Configured Exceptions** tab.
+- **Re-process existing SBOMs separately** to update stored compliance results.
+  Argo syncing and pod rollouts do not perform a license re-scan; the ingestion
+  watcher skips unchanged hashes. Plan and back up any full re-scan, particularly
+  when revoking old approvals.
+
+Do not edit the managed ConfigMap with `kubectl edit` as a normal configuration
+workflow: the next Argo sync or self-heal can overwrite the change. Git is the
+source of truth for the exceptions and their review history.
 
 ---
 
@@ -737,7 +850,7 @@ kubectl exec -it $(kubectl get pod -l app.kubernetes.io/component=api-gateway -o
 | **SBOMs (volume)** | PVC via seed job or git-sync | Push to Git, seed job clones |
 | **SBOMs (push/CI-CD)** | `skipScan` S3 bucket, or PVC | `POST /api/v1/sboms/upload` — see [Option E](#option-e-push-model-uploads-cicd) |
 | **VEX files** | Same S3 bucket or directory | Place `*.openvex.json` alongside SBOMs |
-| **License Exceptions** | ConfigMap | `kubectl edit configmap` → restart API |
+| **License Exceptions** | ConfigMap | `licenseExceptions.custom` in Git → Helm upgrade / [Argo sync](#argo-cd-gitops) → API + worker rollout → re-process existing SBOMs |
 | **License Policy** | ConfigMap | `kubectl edit configmap` → restart API + Workers |
 | **Custom Theme** | ConfigMap | `kubectl create configmap` → restart UI |
 | **Site Config** | ConfigMap | Helm values `ui.siteConfig.content.*` → restart UI |

--- a/docs/content/docs/faq/_index.md
+++ b/docs/content/docs/faq/_index.md
@@ -260,7 +260,7 @@ The `sboms/` directory ships with several example files for testing and demonstr
 | `golang-common.openvex.json` | OpenVEX | Real-world VEX statements for common Go ecosystem false positives. |
 | `otel-protobuf.openvex.json` | OpenVEX | VEX statements for OpenTelemetry protobuf-related findings. |
 | `license-policy.json` | License Policy | The active license classification policy (permissive vs. copyleft SPDX IDs). Based on the [CNCF Allowed Third-Party License Policy](https://github.com/cncf/foundation/blob/main/policies-guidance/allowed-third-party-license-policy.md). |
-| `license-exceptions.json` | License Exceptions | Active license exceptions in [CNCF format](https://github.com/cncf/foundation/blob/main/license-exceptions/exceptions.json). Exempts specific packages from violation reporting. |
+| `license-exceptions.json` | License Exceptions | Empty by default. Add only organization-approved exceptions. An inactive structure example lives in `examples/license-exceptions/`; no CNCF approvals are automatically imported. |
 
 {{% alert title="Tip" color="success" %}}
 Files prefixed with `_` are treated as examples and are skipped by the scanner (configurable via `SBOM_IGNORE_PREFIX`). To include them, set `SBOM_IGNORE_PREFIX=` (empty). You can place any `.json` file in the `sboms/` directory — the format (SPDX, CycloneDX, in-toto) is auto-detected at parse time.

--- a/examples/kind/values-kind.yaml
+++ b/examples/kind/values-kind.yaml
@@ -72,7 +72,6 @@ gitSync:
 seedJob:
   sbomRepo: "https://github.com/cncf/sbom.git"
   sbomBranch: main
-  cncfExceptionsURL: "https://raw.githubusercontent.com/cncf/foundation/main/license-exceptions/exceptions.json"
 
 sbomSource:
   pvcName: bomhort-sbom-data
@@ -85,6 +84,7 @@ sbomSource:
 licenseExceptions:
   enabled: true
   mountPath: /data/config/license-exceptions.json
+  custom: "" # No approvals by default; see examples/license-exceptions/.
 
 licensePolicy:
   enabled: true

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -72,7 +72,10 @@ Used by `values-production.yaml` when `s3.buckets` is empty.
 A Kubernetes Job runs once at install time and:
 1. Does a **shallow `git clone`** of your SBOM repo into a temp directory
 2. **Flat-copies** all `.spdx.json` and `.openvex.json` files into the PVC (flattening nested directory paths into filenames to avoid collisions)
-3. Optionally downloads the [CNCF license exceptions](https://github.com/cncf/foundation/blob/main/license-exceptions/exceptions.json) into the PVC
+
+License exceptions are configured separately through `licenseExceptions.custom`.
+No approvals are downloaded or enabled by default. See the
+[inactive structure example and migration guide](../license-exceptions/README.md).
 
 ```yaml
 s3:
@@ -84,7 +87,6 @@ gitSync:
 seedJob:
   sbomRepo: "https://github.com/cncf/sbom.git"
   sbomBranch: main
-  cncfExceptionsURL: "https://raw.githubusercontent.com/cncf/foundation/main/license-exceptions/exceptions.json"
 
 sbomSource:
   storageSize: 20Gi        # must be large enough for the full repo
@@ -151,8 +153,11 @@ The Ingestion Watcher scans the SBOM directory **recursively** for:
 | `*.spdx.json` | SPDX SBOM | `my-project.spdx.json` |
 | `*.openvex.json` | OpenVEX statement | `my-project.openvex.json` |
 | `*.vex.json` | OpenVEX statement | `my-project.vex.json` |
-| `license-exceptions.json` | CNCF exceptions file | (auto-downloaded by seed job) |
-| `license-policy.json` | Custom license policy | (optional, overrides ConfigMap) |
+
+`license-exceptions.json` and `license-policy.json` are configuration files and
+are **not ingested as SBOMs**. Use their ConfigMaps to configure them.
+The legacy exception-file fallback in the SBOM directory is used only if the
+primary file is absent; an empty ConfigMap is authoritative.
 
 Files are **deduplicated by SHA256 hash** — uploading the same file twice will not create duplicate entries.
 

--- a/examples/kubernetes/values-production.yaml
+++ b/examples/kubernetes/values-production.yaml
@@ -70,8 +70,6 @@ gitSync:
 seedJob:
   sbomRepo: "https://github.com/cncf/sbom.git"    # ← change to your SBOM repo
   sbomBranch: main
-  # Download CNCF license exceptions into the SBOM PVC:
-  cncfExceptionsURL: "https://raw.githubusercontent.com/cncf/foundation/main/license-exceptions/exceptions.json"
 
 sbomSource:
   pvcName: bomhort-sbom-data
@@ -84,6 +82,7 @@ sbomSource:
 licenseExceptions:
   enabled: true
   mountPath: /data/config/license-exceptions.json
+  custom: "" # No approvals by default; see examples/license-exceptions/.
 
 licensePolicy:
   enabled: true

--- a/examples/license-exceptions/README.md
+++ b/examples/license-exceptions/README.md
@@ -1,0 +1,131 @@
+# Organization-managed license exceptions
+
+BOMHort starts with **no license exceptions**. Neither Helm nor Docker Compose
+automatically imports CNCF approvals. The default license **classification policy**
+is separate and is unchanged.
+
+`license-exceptions.example.json` demonstrates the structure, not recommended
+approvals. It is outside the scanned SBOM directory and every example rule is
+`pending`, so copying it alone does not exempt anything.
+
+## Configure
+
+1. Copy the example to `my-exceptions.json`.
+2. Remove unused rules (especially the blanket example), replace placeholders,
+   and review the actual package, project, and license scope with your organization.
+3. Record the approval date and decision reference. Only explicitly approved rules
+   should have `status: "approved"`.
+4. Configure the file through Helm:
+
+   ```bash
+   helm upgrade --install bomhort deploy/helm/bomhort -n bomhort \
+     -f my-values.yaml --set-file licenseExceptions.custom=./my-exceptions.json
+   ```
+
+Keep this file/setting in your deployment configuration for subsequent upgrades.
+Helm accepts `licenseExceptions.custom` as either a JSON string (`--set-file`) or
+a YAML object. Template expressions inside comments are treated as literal data,
+not evaluated using `tpl`.
+
+An explicitly empty values template is:
+
+```yaml
+licenseExceptions:
+  enabled: true
+  custom:
+    version: "1.0.0"
+    blanketExceptions: []
+    exceptions: []
+```
+
+For Docker Compose, put your reviewed configuration in
+`sboms/license-exceptions.json` and recreate/restart both `api-gateway` and
+`parsing-worker`. For standalone binaries, point `EXCEPTIONS_FILE` to the file.
+
+### Argo CD
+
+Use Git-backed `helm.valueFiles` or `helm.valuesObject.licenseExceptions.custom`
+in your Application instead of a local `helm upgrade --set-file` command.
+The [Argo CD example and checklist](../../docs/content/docs/deployment/_index.md#argo-cd-gitops)
+show an inactive `valuesObject` example and explain the required chart/image revisions.
+
+An exception change updates the ConfigMap and both Deployment pod-template
+checksums. Sync all three resources so API and worker pods receive the new file;
+unchanged values do not trigger extra rollouts. Manage approvals in Git, not by
+editing the live ConfigMap. An Argo sync does not re-process existing SBOMs;
+the migration and re-scan requirements below still apply.
+
+## Matching contract
+
+- Both `blanketExceptions` and `exceptions` must be JSON arrays, including when
+  empty. Unknown fields are rejected; use `blanketExceptions`, not
+  `blanket_exceptions`, and `package`, not `purl_prefix`.
+- Only `approved` rules are active (case-insensitive status comparison).
+  `pending` and `revoked` are inactive.
+- `blanketExceptions` intentionally exempts an entire license for **all packages
+  and projects**. Existing SPDX modifier-prefix matching is retained, e.g.
+  `MPL-2.0` also covers `MPL-2.0-no-copyleft-exception`.
+- An `exceptions` rule always requires a package. Names match case-sensitively,
+  exactly or as a complete slash-delimited suffix: `team/library` can match
+  `example.org/team/library`, but not `notteam/library`, `team/library-evil`,
+  or `team/library/submodule`. Prefer fully qualified names to avoid ambiguity.
+  Package PURL/glob patterns are **not** supported.
+- `project` matches the **exact SBOM `document_name`**, not the UI's grouped project
+  label. Omit it or use `"*"` for all projects (`"All Projects"` is retained as a
+  legacy alias). `"All CNCF Projects"` has no special semantics: it is a literal
+  document name and must be migrated deliberately. No project value removes a
+  rule's package restriction.
+- `license` matches exact SPDX IDs. Comma-, ` OR `-, and ` AND `-separated rule
+  values expand into individual license IDs; this is not a full SPDX expression
+  evaluator. Omitting `license` grants **any license** for the named package, so
+  prefer specifying it explicitly.
+- Multiple rules for the same package/license retain their separate project
+  scopes. Matching is deterministic: exact package/license, suffix package/license,
+  exact package-only, then suffix package-only; ties use file order.
+- `scope`, `approvedDate`, `results`, and `comment` are audit metadata, **not**
+  executable conditions. Linkage, modifications, expiry, and deployment cluster
+  are not inferred or enforced.
+
+## Loading and upgrades
+
+The first existing file wins, even if both lists are empty. Only a **missing**
+primary file allows fallback to `SBOM_DIR/license-exceptions.json`. Invalid JSON,
+incorrect structure, or an unreadable file is an error, not permission to load
+another list. The worker stops on invalid configuration; exception-related API
+requests return HTTP 500 instead of pretending there are no configured rules.
+Missing optional files still mean no exceptions.
+
+To disable all approvals, keep the ConfigMap enabled and supply empty lists.
+`licenseExceptions.enabled: false` only disables the Helm mount; a deliberately
+supplied file in `SBOM_DIR` can still be loaded by the legacy fallback.
+
+Migration from older versions:
+
+1. Remove `seedJob.cncfExceptionsURL` from your values (also clear retained Helm
+   values if using `--reuse-values`). The chart rejects the old download option
+   with a migration hint rather than silently changing your approvals.
+2. Review any imported approvals and their package/project restrictions; provide
+   only your intended rules through `licenseExceptions.custom`.
+3. Helm changes now update checksums on **both** API Gateway and worker pod
+   templates. This is necessary because `subPath` ConfigMap mounts do not update
+   in running pods. Direct `kubectl edit configmap` still requires manually
+   restarting both deployments and will be overwritten by Helm upgrades.
+4. **Re-process existing SBOMs** to refresh stored compliance results, especially
+   when revoking/removing previously broad approvals. Ingestion writes exempted
+   and violating packages separately; query-time filtering cannot restore
+   packages omitted by an old approval. Merely restarting services or running
+   the watcher is insufficient because unchanged SBOMs are hash-deduplicated.
+
+Plan and back up a full re-scan for existing installations. The development
+helpers `make re-scan` and `make kind-reingest` are **destructive full rebuilds of
+ingested data**, not license-only refresh commands; do not run them blindly in
+production. This change does not modify or delete deployed data automatically.
+
+## Regression checks
+
+```bash
+cd backend && go test ./internal/license ./cmd/api-gateway -count=1
+# From repository root:
+helm lint deploy/helm/bomhort
+python3 -B -m unittest discover -s deploy/helm/tests -v
+```

--- a/examples/license-exceptions/license-exceptions.example.json
+++ b/examples/license-exceptions/license-exceptions.example.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0.0",
+  "description": "EXAMPLE ONLY. Replace placeholders, review scope, and approve explicitly. Not loaded by default.",
+  "blanketExceptions": [
+    {
+      "id": "example-blanket-review-required",
+      "license": "MPL-2.0",
+      "status": "pending",
+      "approvedDate": "",
+      "scope": "Example only: this rule would exempt this license for EVERY package and project.",
+      "comment": "Remove this rule unless an organization-wide approval is intended."
+    }
+  ],
+  "exceptions": [
+    {
+      "id": "example-package-review-required",
+      "package": "example.org/your-team/your-library",
+      "license": "MPL-2.0",
+      "project": "your-exact-sbom-document-name",
+      "status": "pending",
+      "approvedDate": "",
+      "scope": "Describe the reviewed usage; informational, not evaluated by the matcher.",
+      "results": "https://example.org/your-approval-record",
+      "comment": "Replace package and project, record approval, then change status to approved."
+    }
+  ]
+}

--- a/sboms/license-exceptions.json
+++ b/sboms/license-exceptions.json
@@ -1,48 +1,7 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-03-07",
-  "description": "License exceptions for BOMHort governance. Packages listed here are exempt from license violation reporting.",
-  "blanketExceptions": [
-    {
-      "id": "blanket-mpl-2.0",
-      "license": "MPL-2.0",
-      "status": "approved",
-      "approvedDate": "2026-03-07",
-      "scope": "file-level copyleft, dynamically linked, unmodified",
-      "comment": "MPL-2.0 is file-level copyleft and generally acceptable for infrastructure dependencies when unmodified."
-    }
-  ],
-  "exceptions": [
-    {
-      "id": "exc-2026-03-07-001",
-      "package": "github.com/hashicorp/golang-lru",
-      "license": "MPL-2.0",
-      "project": "All Projects",
-      "status": "approved",
-      "approvedDate": "2026-03-07",
-      "scope": "vendored dependency, dynamically linked, unmodified",
-      "comment": "Widely used LRU cache library. MPL-2.0 is file-level copyleft, acceptable for unmodified use."
-    },
-    {
-      "id": "exc-2026-03-07-002",
-      "package": "github.com/hashicorp/go-multierror",
-      "license": "MPL-2.0",
-      "project": "All Projects",
-      "status": "approved",
-      "approvedDate": "2026-03-07",
-      "scope": "vendored dependency, unmodified",
-      "comment": "Error aggregation utility. Unmodified transitive dependency."
-    },
-    {
-      "id": "exc-2026-03-07-003",
-      "package": "go.uber.org/mock",
-      "license": "Apache-2.0",
-      "project": "Antrea",
-      "status": "approved",
-      "approvedDate": "2026-03-07",
-      "scope": "test-only dependency",
-      "comment": "Mock framework used only in tests, not shipped in production binaries."
-    }
-  ]
+  "description": "No exceptions configured. See examples/license-exceptions/ for an inactive example to adapt and review.",
+  "blanketExceptions": [],
+  "exceptions": []
 }
 

--- a/ui/src/app/features/search/license-violations.component.spec.ts
+++ b/ui/src/app/features/search/license-violations.component.spec.ts
@@ -2,6 +2,9 @@ import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { vi } from 'vitest';
+import { ApiService } from '../../core/api.service';
 import { LicenseViolationsComponent } from './license-violations.component';
 
 describe('LicenseViolationsComponent', () => {
@@ -33,6 +36,55 @@ describe('LicenseViolationsComponent', () => {
     const fixture = TestBed.createComponent(LicenseViolationsComponent);
     const component = fixture.componentInstance;
     expect(component.activeTab).toBe('non-compliant');
+  });
+
+  it('should display empty defaults without claiming all packages are exempt', () => {
+    const api = TestBed.inject(ApiService);
+    vi.spyOn(api, 'getProjectsWithLicenseViolations').mockReturnValue(of([]));
+    vi.spyOn(api, 'getLicenseExceptions').mockReturnValue(of({
+      version: '1.0.0', lastUpdated: '', blanketExceptions: [], exceptions: [],
+    }));
+    const fixture = TestBed.createComponent(LicenseViolationsComponent);
+    fixture.detectChanges();
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain('Configured Exceptions (0)');
+    expect(element.textContent).not.toContain('All items are covered by exceptions');
+    const button = element.querySelectorAll('button')[1] as HTMLButtonElement;
+    button.click();
+    fixture.detectChanges();
+    expect(element.textContent).toContain('No exceptions configured');
+    expect(element.textContent).toContain('only approved rules apply');
+    expect(element.textContent).toContain('re-process existing SBOMs');
+  });
+
+  it('should describe pending and revoked entries as configured, not active', () => {
+    const api = TestBed.inject(ApiService);
+    vi.spyOn(api, 'getProjectsWithLicenseViolations').mockReturnValue(of([]));
+    vi.spyOn(api, 'getLicenseExceptions').mockReturnValue(of({
+      version: '1.0.0', lastUpdated: '', blanketExceptions: [],
+      exceptions: ['pending', 'revoked'].map(status => ({
+        id: status, package: 'example.org/library', license: 'MPL-2.0',
+        status, approvedDate: '',
+      })),
+    }));
+    const fixture = TestBed.createComponent(LicenseViolationsComponent);
+    fixture.detectChanges();
+    const text = (fixture.nativeElement as HTMLElement).textContent;
+    expect(text).toContain('Configured Exceptions (2)');
+    expect(text).not.toContain('Active Exceptions');
+  });
+
+  it('should show configuration errors instead of an empty-success message', () => {
+    const api = TestBed.inject(ApiService);
+    vi.spyOn(api, 'getProjectsWithLicenseViolations').mockReturnValue(of([]));
+    vi.spyOn(api, 'getLicenseExceptions').mockReturnValue(throwError(() => new Error('Invalid configuration')));
+    const fixture = TestBed.createComponent(LicenseViolationsComponent);
+    fixture.componentInstance.activeTab = 'exceptions';
+    fixture.detectChanges();
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.querySelector('[role="alert"]')?.textContent).toContain('invalid files are rejected');
+    expect(element.textContent).not.toContain('No exceptions configured');
+    expect(fixture.componentInstance.loaded).toBe(false);
   });
 });
 

--- a/ui/src/app/features/search/license-violations.component.ts
+++ b/ui/src/app/features/search/license-violations.component.ts
@@ -17,13 +17,14 @@ type Tab = 'non-compliant' | 'exceptions';
     <div class="violations-page">
       <h1>License Compliance</h1>
       <p class="subtitle">Non-compliant licenses filtered by configured exceptions. Exceptions are managed via <code>license-exceptions.json</code>.</p>
+      <p *ngIf="loadError" role="alert" class="load-error">{{ loadError }}</p>
 
       <div class="tabs">
         <button [class.active]="activeTab === 'non-compliant'" (click)="activeTab = 'non-compliant'">
           Non-Compliant ({{ violations.length | number }})
         </button>
         <button [class.active]="activeTab === 'exceptions'" (click)="activeTab = 'exceptions'">
-          Active Exceptions ({{ totalExceptions | number }})
+          Configured Exceptions ({{ totalExceptions | number }})
         </button>
       </div>
 
@@ -47,7 +48,7 @@ type Tab = 'non-compliant' | 'exceptions';
           </div>
         </cdk-virtual-scroll-viewport>
         <p *ngIf="loaded && violations.length === 0" class="empty">
-          No non-compliant licenses found. All items are covered by exceptions.
+          No non-compliant licenses found in the stored results.
         </p>
       </div>
 
@@ -56,12 +57,14 @@ type Tab = 'non-compliant' | 'exceptions';
         <div class="config-hint">
           <span class="hint-icon">ℹ</span>
           Exceptions are loaded from <code>license-exceptions.json</code> in the config volume.
-          Edit the file and restart the API to apply changes.
+          No exceptions are enabled by default; only approved rules apply.
+          Configure <code>licenseExceptions.custom</code> through Helm to roll out API and workers,
+          then re-process existing SBOMs. Direct file edits require restarting both services.
         </div>
 
         <div class="exceptions-section" *ngIf="exceptionsFile.blanketExceptions.length > 0">
           <h2>Blanket Exceptions</h2>
-          <p class="section-desc">Entire licenses exempted from violation reporting.</p>
+          <p class="section-desc">Approved rules exempt entire licenses for all packages and projects. Pending and revoked rules are inactive.</p>
           <div *ngFor="let be of exceptionsFile.blanketExceptions" class="exception-card blanket">
             <div class="exc-row">
               <span class="exc-license">{{ be.license }}</span>
@@ -75,7 +78,7 @@ type Tab = 'non-compliant' | 'exceptions';
 
         <div class="exceptions-section" *ngIf="exceptionsFile.exceptions.length > 0">
           <h2>Package Exceptions</h2>
-          <p class="section-desc">Specific package + license combinations exempted.</p>
+          <p class="section-desc">Approved package + license rules, optionally restricted to an exact SBOM document name. Scope descriptions are informational.</p>
           <div *ngFor="let exc of exceptionsFile.exceptions" class="exception-card">
             <div class="exc-row">
               <span class="exc-pkg">{{ exc.package }}</span>
@@ -89,7 +92,7 @@ type Tab = 'non-compliant' | 'exceptions';
           </div>
         </div>
 
-        <p *ngIf="totalExceptions === 0" class="empty-hint">
+        <p *ngIf="loaded && totalExceptions === 0" class="empty-hint">
           No exceptions configured. Add entries to <code>license-exceptions.json</code> to suppress known non-compliant licenses.
         </p>
       </div>
@@ -123,6 +126,7 @@ type Tab = 'non-compliant' | 'exceptions';
     .licenses { font-style: normal; }
     .pkgs { margin-left: 8px; }
     .empty { color: var(--status-success); font-size: 0.9rem; font-weight: 500; }
+    .load-error { color: var(--severity-critical); font-size: 0.85rem; }
 
     .config-hint {
       display: flex; align-items: flex-start; gap: 8px; padding: 10px 14px;
@@ -159,6 +163,7 @@ export class LicenseViolationsComponent implements OnInit {
     version: '1.0.0', lastUpdated: '', blanketExceptions: [], exceptions: [],
   };
   loaded = false;
+  loadError = '';
   activeTab: Tab = 'non-compliant';
 
   constructor(
@@ -170,11 +175,17 @@ export class LicenseViolationsComponent implements OnInit {
     forkJoin({
       violations: this.api.getProjectsWithLicenseViolations(),
       exceptions: this.api.getLicenseExceptions(),
-    }).subscribe(({ violations, exceptions }) => {
-      this.violations = violations;
-      this.exceptionsFile = exceptions;
-      this.loaded = true;
-      this.cdr.markForCheck();
+    }).subscribe({
+      next: ({ violations, exceptions }) => {
+        this.violations = violations;
+        this.exceptionsFile = exceptions;
+        this.loaded = true;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.loadError = 'Could not load license compliance. Check API availability and the license exceptions configuration; invalid files are rejected.';
+        this.cdr.markForCheck();
+      },
     });
   }
 


### PR DESCRIPTION
## Description

**Bugfix:** make existing license exceptions reliable and organization-neutral across the backend, Helm/Argo CD deployments, and UI.

The previous implementation ignored custom Helm exceptions, skipped explicitly empty configuration files in favor of stale fallback approvals, promoted `All CNCF Projects` package rules into global license exemptions, and ignored other project restrictions. ConfigMap changes also did not roll out the consuming pods, and the documented JSON example contained unsupported field names.

### Fixes

- Support `licenseExceptions.custom` as a YAML object or JSON string / file, validate the required arrays, and add deterministic ConfigMap checksums to both API Gateway and parsing-worker pod templates.
- Ship empty exception defaults and an isolated, inactive example instead of pre-approved rules or automatic CNCF exception downloads.
- Treat an existing empty file as authoritative; fall back only when the primary file is missing. Reject unknown JSON fields, malformed documents, and unreadable configuration instead of silently loading another list.
- Preserve package restrictions, enforce exact SBOM document-name project scopes in worker and API matching, retain multiple project-scoped rules, and replace arbitrary substring matching with case-sensitive exact/path-segment suffix matching.
- Surface invalid configuration through worker startup errors and exception-related API HTTP 500 responses. Show UI errors and distinguish configured rules from active approvals.
- Add backend/API/UI and Helm-rendering regression coverage; run the Helm tests in CI.
- Update `docs/ARCHITECTURE_PLAN.md`, both deployment guides, published architecture/API/FAQ pages, and examples. Include an Argo CD `valuesObject` example and sync/migration checklist.

### Compatibility and deployment notes

This is a correctness **bugfix**, with intentional configuration compatibility changes that operators must review:

1. Remove the retired `seedJob.cncfExceptionsURL` setting from all Helm/Argo values and parameters; the chart now rejects it with a migration hint. Supply reviewed organization-specific rules through `licenseExceptions.custom`.
2. Review previously broad approvals. `All CNCF Projects` is now a literal project name, not a global exemption; package/project boundaries are enforced.
3. Both `blanketExceptions` and `exceptions` arrays are required. Invalid or unknown JSON fields are rejected rather than ignored.
4. Deploy chart and API/worker images containing the fixes. Argo CD sync applies the ConfigMap plus both Deployment checksum changes; no Helm upgrade hook or manual restart is required for normal GitOps updates.
5. Re-process existing SBOMs to refresh persisted compliance results, particularly after revocation. A pod rollout or watcher run alone is insufficient because existing results persist and unchanged SBOMs are hash-deduplicated. No automatic data reset or re-scan is introduced.

The default license classification policy is unchanged. No ClickHouse schema changes or new dependencies are introduced.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] 🏗️ Infrastructure / CI / Helm

The breaking-change checkbox documents the intentional migration requirements above; this PR fixes existing exception behavior rather than adding a new feature.

## Component(s) Affected

- [x] API Gateway
- [x] Parsing Worker
- [ ] Ingestion Watcher
- [ ] ClickHouse Schema / Migrations
- [x] Angular UI
- [x] Helm Chart
- [x] Documentation

## Related Issues

No issue number provided. Addresses the reported license-exception and Helm-template bugs.

## How Has This Been Tested?

- [x] `go test ./...` passes
- [x] `ng build` passes
- [x] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [ ] Manual testing on Kubernetes

Additional validation:

- Full backend suite: `go test ./... -count=1 -race`; `go build ./...`; `go vet ./...`.
- Helm: `python3 -B -m unittest discover -s deploy/helm/tests -v` — 7 tests covering empty defaults, custom mappings/JSON/files, mount paths, both rollout checksums, disabled mounts, invalid configuration, and retired download settings.
- Frontend: `ng test --watch=false` — 69 tests across 17 files, including 6 license-compliance component tests; production build with Node 24.15.0.
- Argo-style local rendering: repeated `helm template` with namespace, Kubernetes version, and CRDs produced identical full-chart output. Revocation and empty lists changed both Deployment checksums. This was checked with Helm 4.2.0, not a live Argo CD instance.
- Hugo documentation build passed; the generated Argo CD section/example and anchor were checked.
- `git diff --cached --check` passed.

## Checklist

- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [x] I have added tests that prove my fix/feature works ([docs/TESTING.md](docs/TESTING.md))
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have signed off my commits (DCO)

Warning note: validation succeeds with non-blocking Angular optional-chain/style-budget warnings and Hugo deprecation warnings. Helm can also emit a values-coalescing warning when a custom mapping overrides the default string value; the rendered configuration is verified by tests. The warning-free checkbox is intentionally left unchecked.

## Screenshots (if applicable)

Not captured. UI changes update configuration guidance, label the list as **Configured Exceptions**, and display loading/configuration failures rather than misleading empty-success messages. These behaviors are covered by component tests.

