### PR TITLE
fix(sbom): resolve temporary document names from described roots

### DIFF
--- a/backend/internal/cyclonedx/parser.go
+++ b/backend/internal/cyclonedx/parser.go
@@ -11,6 +11,7 @@ import (
 	json "github.com/goccy/go-json"
 	"github.com/google/uuid"
 
+	"github.com/seebom-labs/bomhort/backend/internal/sbomname"
 	"github.com/seebom-labs/bomhort/backend/pkg/models"
 )
 
@@ -33,8 +34,8 @@ type CDXDocument struct {
 
 // CDXMetadata holds BOM metadata.
 type CDXMetadata struct {
-	Timestamp string    `json:"timestamp"`
-	Tools     []CDXTool `json:"tools"`
+	Timestamp string        `json:"timestamp"`
+	Tools     []CDXTool     `json:"tools"`
 	Component *CDXComponent `json:"component"`
 }
 
@@ -47,11 +48,11 @@ type CDXTool struct {
 
 // CDXComponent represents a single component in the BOM.
 type CDXComponent struct {
-	Type    string       `json:"type"`
-	BomRef  string       `json:"bom-ref"`
-	Name    string       `json:"name"`
-	Version string       `json:"version"`
-	PURL    string       `json:"purl"`
+	Type     string       `json:"type"`
+	BomRef   string       `json:"bom-ref"`
+	Name     string       `json:"name"`
+	Version  string       `json:"version"`
+	PURL     string       `json:"purl"`
 	Licenses []CDXLicense `json:"licenses"`
 }
 
@@ -106,16 +107,18 @@ func Parse(data []byte, sourceFile, sha256Hash string) (*ParseResult, error) {
 		tools = append(tools, "Tool: "+toolStr)
 	}
 
-	// Document name: use metadata component name or serial number.
+	// Keep meaningful component names; resolve unusable ones before a version
+	// suffix can disguise a temporary/empty name as a meaningful document name.
 	docName := ""
 	if doc.Metadata.Component != nil {
 		docName = doc.Metadata.Component.Name
-		if doc.Metadata.Component.Version != "" {
+		if !sbomname.NeedsFallback(docName) && doc.Metadata.Component.Version != "" {
 			docName += " " + doc.Metadata.Component.Version
 		}
 	}
-	if docName == "" {
-		docName = doc.SerialNumber
+	docName, err = sbomname.Resolve(data, docName, sourceFile)
+	if err != nil {
+		return nil, err
 	}
 
 	sbom := models.SBOM{
@@ -224,4 +227,3 @@ func extractLicense(lics []CDXLicense) string {
 	}
 	return strings.Join(parts, " AND ")
 }
-

--- a/backend/internal/protobomparser/parser.go
+++ b/backend/internal/protobomparser/parser.go
@@ -15,6 +15,7 @@ import (
 	"github.com/protobom/protobom/pkg/reader"
 	"github.com/protobom/protobom/pkg/sbom"
 
+	"github.com/seebom-labs/bomhort/backend/internal/sbomname"
 	"github.com/seebom-labs/bomhort/backend/pkg/models"
 )
 
@@ -37,7 +38,16 @@ func Parse(data []byte, sourceFile, sha256Hash string) (*ParseResult, error) {
 		return nil, fmt.Errorf("protobom: failed to parse %s: %w", sourceFile, err)
 	}
 
-	return convertDocument(doc, sourceFile, sha256Hash)
+	result, err := convertDocument(doc, sourceFile, sha256Hash)
+	if err != nil {
+		return nil, err
+	}
+	name, err := sbomname.Resolve(data, result.SBOM.DocumentName, sourceFile)
+	if err != nil {
+		return nil, err
+	}
+	result.SBOM.DocumentName = name
+	return result, nil
 }
 
 // ParseReader reads from an io.Reader and parses via protobom.
@@ -231,4 +241,3 @@ func detectFormat(doc *sbom.Document) string {
 
 	return "Unknown"
 }
-

--- a/backend/internal/sbom/document_name_test.go
+++ b/backend/internal/sbom/document_name_test.go
@@ -1,0 +1,143 @@
+package sbom
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/seebom-labs/bomhort/backend/internal/license"
+)
+
+func namingFixture(t *testing.T) []byte {
+	t.Helper()
+	data, err := os.ReadFile("testdata/temporary-document.spdx.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func TestDocumentNameFallbackAcrossBackends(t *testing.T) {
+	data := namingFixture(t)
+	const source = "s3://bucket/example-org/widget/v1.2.3/widget_spdx.json"
+	for _, tt := range []struct{ name, from, to, want string }{
+		{"temporary", "", "", "example-org/widget v1.2.3"},
+		{"empty", `"name": "tmp.ABC123xyz"`, `"name": ""`, "example-org/widget v1.2.3"},
+		{"valid", `"name": "tmp.ABC123xyz"`, `"name": "Published title"`, "Published title"},
+		{"root name temporary", `"name": "example-org/widget"`, `"name": "tmp.XYZ987abc"`, "example-org/widget/v1.2.3/widget"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			input := data
+			if tt.from != "" {
+				input = []byte(strings.Replace(string(data), tt.from, tt.to, 1))
+			}
+			before := append([]byte(nil), input...)
+			for _, backend := range []struct {
+				name  string
+				parse func([]byte, string, string) (*ParseResult, error)
+			}{{"builtin", parseSPDX}, {"protobom", parseWithProtobom}} {
+				t.Run(backend.name, func(t *testing.T) {
+					result, err := backend.parse(input, source, "fixture-hash")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if result.SBOM.DocumentName != tt.want {
+						t.Fatalf("name=%q, want %q", result.SBOM.DocumentName, tt.want)
+					}
+					if result.SBOM.SourceFile != source || result.SBOM.SHA256Hash != "fixture-hash" {
+						t.Fatal("source identity changed")
+					}
+					if !bytes.Equal(input, before) {
+						t.Fatal("source bytes changed")
+					}
+					// Compare with the same backend parsing the same packages under a
+					// valid document name; only the displayed document name may differ.
+					var doc map[string]any
+					if err := json.Unmarshal(input, &doc); err != nil {
+						t.Fatal(err)
+					}
+					doc["name"] = "Reference document"
+					control, err := json.Marshal(doc)
+					if err != nil {
+						t.Fatal(err)
+					}
+					baseline, err := backend.parse(control, source, "fixture-hash")
+					if err != nil {
+						t.Fatal(err)
+					}
+					if result.SBOM.SBOMID != baseline.SBOM.SBOMID || result.SBOM.DocumentNamespace != baseline.SBOM.DocumentNamespace {
+						t.Fatal("SBOM identity/namespace changed")
+					}
+					actualPackages, expectedPackages := result.Packages, baseline.Packages
+					actualPackages.IngestedAt = expectedPackages.IngestedAt
+					if !reflect.DeepEqual(actualPackages, expectedPackages) {
+						t.Fatal("package identities, licenses, or relationships changed")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestDocumentNameFallbackSPDXEnvelope(t *testing.T) {
+	envelope := `{"predicateType":"https://spdx.dev/Document","predicate":` + string(namingFixture(t)) + `}`
+	result, err := parseSPDX([]byte(envelope), "attestation.json", "fixture-hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SBOM.DocumentName != "example-org/widget v1.2.3" {
+		t.Fatalf("unexpected name %q", result.SBOM.DocumentName)
+	}
+}
+
+func TestDocumentNameFallbackCycloneDX(t *testing.T) {
+	for _, tt := range []struct{ component, serial, want string }{
+		{`{"type":"application","name":"widget","version":"1.0"}`, "", "widget 1.0"},
+		{`{"type":"application","name":"tmp.ABC123xyz","version":"1.0"}`, "", "widget"},
+		{`{"type":"application","name":"","version":"1.0"}`, "", "widget"},
+		{`null`, "", "widget"},
+		{`null`, "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79", "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"},
+	} {
+		input := []byte(`{"bomFormat":"CycloneDX","specVersion":"1.5","serialNumber":"` + tt.serial + `","version":1,"metadata":{"component":` + tt.component + `},"components":[{"type":"library","name":"not-the-root","version":"5"}]}`)
+		for _, parse := range []func([]byte, string, string) (*ParseResult, error){parseCycloneDX, parseWithProtobom} {
+			result, err := parse(input, "widget.cdx.json", "fixture-hash")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.SBOM.DocumentName != tt.want {
+				t.Errorf("component=%s: name=%q want=%q", tt.component, result.SBOM.DocumentName, tt.want)
+			}
+		}
+	}
+}
+
+func TestNormalizedDocumentNameUsesExactLicenseProjectScope(t *testing.T) {
+	for _, parse := range []func([]byte, string, string) (*ParseResult, error){parseSPDX, parseWithProtobom} {
+		result, err := parse(namingFixture(t), "widget.spdx.json", "fixture-hash")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, project := range []string{"example-org/widget v1.2.3", "example-org/widget v2.0.0", "tmp.ABC123xyz"} {
+			idx := license.BuildIndex(&license.ExceptionsFile{Exceptions: []license.Exception{{
+				ID: "scoped", Package: "unrelated-dependency", License: "MPL-2.0", Status: "approved", Project: project,
+			}}})
+			results := license.CheckWithExceptions(result.Packages.PackageNames, result.Packages.PackageLicenses, idx, result.SBOM.DocumentName)
+			found := false
+			for _, check := range results {
+				if check.LicenseID != "MPL-2.0" {
+					continue
+				}
+				found = true
+				if (len(check.ExemptedPackages) == 1) != (project == result.SBOM.DocumentName) {
+					t.Fatalf("project %q applied incorrectly: %+v", project, check)
+				}
+			}
+			if !found {
+				t.Fatal("missing copyleft result")
+			}
+		}
+	}
+}

--- a/backend/internal/sbom/testdata/temporary-document.spdx.json
+++ b/backend/internal/sbom/testdata/temporary-document.spdx.json
@@ -1,0 +1,41 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "tmp.ABC123xyz",
+  "documentNamespace": "https://example.org/sbom/naming-regression",
+  "creationInfo": {
+    "created": "2026-09-08T00:00:00Z",
+    "creators": ["Tool: naming-regression-fixture"]
+  },
+  "documentDescribes": ["SPDXRef-Root"],
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Dependency",
+      "name": "unrelated-dependency",
+      "versionInfo": "9.0.0",
+      "downloadLocation": "NOASSERTION",
+      "licenseDeclared": "MPL-2.0",
+      "licenseConcluded": "MPL-2.0"
+    },
+    {
+      "SPDXID": "SPDXRef-Root",
+      "name": "example-org/widget",
+      "versionInfo": "v1.2.3",
+      "downloadLocation": "NOASSERTION",
+      "licenseDeclared": "Apache-2.0",
+      "licenseConcluded": "Apache-2.0",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:generic/example-org%2Fwidget@v1.2.3"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {"spdxElementId": "SPDXRef-DOCUMENT", "relationshipType": "DESCRIBES", "relatedSpdxElement": "SPDXRef-Root"},
+    {"spdxElementId": "SPDXRef-Root", "relationshipType": "DEPENDS_ON", "relatedSpdxElement": "SPDXRef-Dependency"}
+  ]
+}

--- a/backend/internal/sbomname/name.go
+++ b/backend/internal/sbomname/name.go
@@ -1,0 +1,199 @@
+// Package sbomname resolves unusable SBOM document names without changing source
+// documents, package identities, or meaningful existing names.
+package sbomname
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/url"
+	"path"
+	"regexp"
+	"strings"
+
+	json "github.com/goccy/go-json"
+)
+
+var tempName = regexp.MustCompile(`^tmp(?:\.[a-zA-Z0-9]{6,})?$`)
+
+// NeedsFallback recognizes empty names and conservative temporary-directory
+// patterns, including absolute Unix/Windows paths ending in tmp.XXXXXX.
+// It deliberately leaves ordinary names such as tmp-utils and org/tmp.tool alone.
+func NeedsFallback(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return true
+	}
+	normalized := strings.ReplaceAll(name, `\`, "/")
+	if strings.HasPrefix(normalized, "/") || (len(normalized) > 2 && normalized[1:3] == ":/") {
+		name = path.Base(normalized)
+	}
+	return tempName.MatchString(name)
+}
+
+type component struct {
+	ID      string `json:"SPDXID"`
+	Name    string `json:"name"`
+	Version string `json:"versionInfo"`
+}
+
+// Read raw root metadata rather than relying on a parser library's inferred
+// graph roots. This keeps both backends consistent for missing/multiple roots.
+type document struct {
+	ID                string      `json:"SPDXID"`
+	Name              string      `json:"name"`
+	SPDXVersion       string      `json:"spdxVersion"`
+	DocumentDescribes []string    `json:"documentDescribes"`
+	Packages          []component `json:"packages"`
+	Relationships     []struct {
+		From string `json:"spdxElementId"`
+		Type string `json:"relationshipType"`
+		To   string `json:"relatedSpdxElement"`
+	} `json:"relationships"`
+	BomFormat    string `json:"bomFormat"`
+	SerialNumber string `json:"serialNumber"`
+	Metadata     struct {
+		Component *struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"component"`
+	} `json:"metadata"`
+	PredicateType string          `json:"predicateType"`
+	Predicate     json.RawMessage `json:"predicate"`
+}
+
+// Resolve returns an existing usable name verbatim. Only unusable names trigger
+// an additional metadata pass: a unique described root + version, then a source
+// label, and finally "Unnamed SBOM". CycloneDX's serial-number fallback is retained.
+// Original names remain in the source document and are logged with the resolution;
+// no schema change or mutation of the input bytes is required.
+func Resolve(data []byte, original, source string) (string, error) {
+	if !NeedsFallback(original) {
+		return original, nil
+	}
+	var doc document
+	// Protobom also accepts XML. Its parser has already validated the input;
+	// JSON-specific root extraction must not reject otherwise supported formats.
+	if !bytes.HasPrefix(bytes.TrimSpace(data), []byte("<")) {
+		if err := json.Unmarshal(data, &doc); err != nil {
+			return "", fmt.Errorf("decode SBOM naming metadata: %w", err)
+		}
+	}
+	if doc.SPDXVersion == "" && strings.Contains(doc.PredicateType, "spdx") && len(doc.Predicate) > 0 {
+		var inner document
+		if err := json.Unmarshal(doc.Predicate, &inner); err != nil {
+			return "", fmt.Errorf("decode in-toto naming metadata: %w", err)
+		}
+		doc = inner
+	}
+
+	name, reason := "", ""
+	switch {
+	case doc.SPDXVersion != "":
+		if !NeedsFallback(doc.Name) {
+			name, reason = doc.Name, "document"
+		} else if root := describedRoot(doc); root != nil && !NeedsFallback(root.Name) {
+			name, reason = withVersion(root.Name, root.Version), "described-root"
+		}
+	case doc.BomFormat == "CycloneDX":
+		if root := doc.Metadata.Component; root != nil && !NeedsFallback(root.Name) {
+			name, reason = withVersion(root.Name, root.Version), "metadata-component"
+		} else if !NeedsFallback(doc.SerialNumber) {
+			name, reason = doc.SerialNumber, "serial-number"
+		}
+	}
+	if name == "" {
+		name, reason = sourceName(source), "source"
+	}
+	if name == "" {
+		name, reason = "Unnamed SBOM", "unnamed"
+	}
+	// Quote untrusted metadata and bound its length to avoid multiline/oversized logs.
+	log.Printf("SBOM document name fallback: source=%q original=%q resolved=%q reason=%s",
+		abbreviate(sourceName(source)), abbreviate(original), abbreviate(name), reason)
+	return name, nil
+}
+
+func describedRoot(doc document) *component {
+	ids := make(map[string]bool)
+	for _, id := range doc.DocumentDescribes {
+		ids[id] = true
+	}
+	docID := doc.ID
+	if docID == "" {
+		docID = "SPDXRef-DOCUMENT"
+	}
+	for _, rel := range doc.Relationships {
+		switch {
+		case rel.Type == "DESCRIBES" && rel.From == docID:
+			ids[rel.To] = true
+		case rel.Type == "DESCRIBED_BY" && rel.To == docID:
+			ids[rel.From] = true
+		}
+	}
+	// Do not guess from package order, dependency roots, or only the subset of
+	// references that happened to resolve. Dangling/multiple references are ambiguous.
+	if len(ids) != 1 || ids[""] {
+		return nil
+	}
+	var root *component
+	for i := range doc.Packages {
+		if ids[doc.Packages[i].ID] {
+			if root != nil { // Duplicate package IDs are also ambiguous.
+				return nil
+			}
+			root = &doc.Packages[i]
+		}
+	}
+	return root
+}
+
+func withVersion(name, version string) string {
+	name, version = strings.TrimSpace(name), strings.TrimSpace(version)
+	switch strings.ToUpper(version) {
+	case "", "NOASSERTION", "NONE", "UNKNOWN":
+		return name
+	default:
+		return name + " " + version
+	}
+}
+
+func sourceName(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return ""
+	}
+	var label string
+	if strings.Contains(source, "://") {
+		u, err := url.Parse(source)
+		if err != nil {
+			return ""
+		}
+		// Keep the full S3 object key (project/version context), but never URL
+		// credentials, query parameters, or fragments. Other URLs use the basename.
+		if u.Scheme == "s3" {
+			label = strings.TrimLeft(u.Path, "/")
+		} else {
+			label = path.Base(u.Path)
+		}
+	} else {
+		label = path.Base(strings.ReplaceAll(source, `\`, "/"))
+	}
+	for _, suffix := range []string{".spdx.json", "_spdx.json", ".cdx.json", ".json"} {
+		if strings.HasSuffix(strings.ToLower(label), suffix) {
+			label = label[:len(label)-len(suffix)]
+			break
+		}
+	}
+	if label == "." || label == "/" || NeedsFallback(label) {
+		return ""
+	}
+	return label
+}
+
+func abbreviate(value string) string {
+	if len(value) > 256 {
+		return value[:256] + "..."
+	}
+	return value
+}

--- a/backend/internal/sbomname/name_test.go
+++ b/backend/internal/sbomname/name_test.go
@@ -1,0 +1,143 @@
+package sbomname
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestNeedsFallback(t *testing.T) {
+	for _, name := range []string{"", " \n\t", "tmp", "tmp.ABC123xyz", "/tmp/tmp.ABC123xyz", "/tmp/tmp.ABC123xyz/", `C:\Temp\tmp.ABC123xyz`} {
+		if !NeedsFallback(name) {
+			t.Errorf("expected fallback for %q", name)
+		}
+	}
+	for _, name := range []string{"project", "tmp-utils", "tmp.txt", "tmp.tool", "org/tmp.ABC123xyz", "Production tmp.ABC123xyz", "  Release Name  "} {
+		if NeedsFallback(name) {
+			t.Errorf("must preserve meaningful name %q", name)
+		}
+	}
+}
+
+func TestResolvePreservesExistingNameWithoutReparsing(t *testing.T) {
+	name := "  My Project 1.0  "
+	got, err := Resolve([]byte("not needed for a valid name"), name, "source.json")
+	if err != nil || got != name {
+		t.Fatalf("got %q, %v; want original verbatim", got, err)
+	}
+}
+
+func TestResolveSPDX(t *testing.T) {
+	const packages = `"packages":[{"SPDXID":"dep","name":"wrong-dependency","versionInfo":"9"},{"SPDXID":"root","name":"example/widget","versionInfo":"v1.2.3"}]`
+	for _, tt := range []struct {
+		name, fields, want string
+	}{
+		{"documentDescribes", `"documentDescribes":["root"],` + packages, "example/widget v1.2.3"},
+		{"DESCRIBES", `"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"root"}],` + packages, "example/widget v1.2.3"},
+		{"DESCRIBED_BY", `"relationships":[{"spdxElementId":"root","relationshipType":"DESCRIBED_BY","relatedSpdxElement":"SPDXRef-DOCUMENT"}],` + packages, "example/widget v1.2.3"},
+		{"duplicate references", `"documentDescribes":["root","root"],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"root"}],` + packages, "example/widget v1.2.3"},
+		{"custom document ID", `"SPDXID":"document","relationships":[{"spdxElementId":"document","relationshipType":"DESCRIBES","relatedSpdxElement":"root"}],` + packages, "example/widget v1.2.3"},
+		{"missing roots", packages, "team/widget/v1/widget"},
+		{"unrelated DESCRIBES", `"relationships":[{"spdxElementId":"dep","relationshipType":"DESCRIBES","relatedSpdxElement":"root"}],` + packages, "team/widget/v1/widget"},
+		{"multiple roots", `"documentDescribes":["dep","root"],` + packages, "team/widget/v1/widget"},
+		{"dangling root", `"documentDescribes":["missing"],` + packages, "team/widget/v1/widget"},
+		{"partly dangling roots", `"documentDescribes":["missing","root"],` + packages, "team/widget/v1/widget"},
+		{"empty root reference", `"documentDescribes":[""],` + packages, "team/widget/v1/widget"},
+		{"temporary root", `"documentDescribes":["root"],"packages":[{"SPDXID":"root","name":"tmp.ABC123xyz","versionInfo":"1"}]`, "team/widget/v1/widget"},
+		{"empty root name", `"documentDescribes":["root"],"packages":[{"SPDXID":"root","name":"","versionInfo":"1"}]`, "team/widget/v1/widget"},
+		{"duplicate package IDs", `"documentDescribes":["root"],"packages":[{"SPDXID":"root","name":"a"},{"SPDXID":"root","name":"b"}]`, "team/widget/v1/widget"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte(`{"spdxVersion":"SPDX-2.3","name":"tmp.ABC123xyz",` + tt.fields + `}`)
+			original := append([]byte(nil), data...)
+			got, err := Resolve(data, "tmp.ABC123xyz", "s3://bucket/team/widget/v1/widget.spdx.json")
+			if err != nil || got != tt.want {
+				t.Fatalf("got %q, %v; want %q", got, err, tt.want)
+			}
+			if !bytes.Equal(data, original) {
+				t.Fatal("source bytes were mutated")
+			}
+		})
+	}
+}
+
+func TestResolveEnvelopeAndCycloneDX(t *testing.T) {
+	for _, tt := range []struct{ name, data, want string }{
+		{"envelope", `{"predicateType":"https://spdx.dev/Document","predicate":{"spdxVersion":"SPDX-2.3","name":"tmp.ABC123xyz","documentDescribes":["root"],"packages":[{"SPDXID":"root","name":"widget","versionInfo":"1"}]}}`, "widget 1"},
+		{"cdx root", `{"bomFormat":"CycloneDX","metadata":{"component":{"name":"widget","version":"1"}}}`, "widget 1"},
+		{"cdx serial", `{"bomFormat":"CycloneDX","serialNumber":"urn:uuid:example","metadata":{"component":{"name":"tmp.ABC123xyz","version":"1"}}}`, "urn:uuid:example"},
+		{"cdx no root", `{"bomFormat":"CycloneDX","components":[{"name":"dependency"}]}`, "source"},
+		{"cdx blank root", `{"bomFormat":"CycloneDX","metadata":{"component":{"name":"","version":"1"}}}`, "source"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Resolve([]byte(tt.data), "", "source.json")
+			if err != nil || got != tt.want {
+				t.Fatalf("got %q, %v; want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionPlaceholders(t *testing.T) {
+	for _, version := range []string{"", "NOASSERTION", "NONE", "unknown", " UNKNOWN "} {
+		if got := withVersion("widget", version); got != "widget" {
+			t.Errorf("placeholder %q appended: %q", version, got)
+		}
+	}
+}
+
+func TestSourceFallback(t *testing.T) {
+	for _, tt := range []struct{ source, want string }{
+		{"s3://bucket/org/project/v1/bom_spdx.json", "org/project/v1/bom"},
+		{"s3://bucket/project/v1/file.json", "project/v1/file"},
+		{"/tmp/downloads/widget.spdx.json", "widget"},
+		{`C:\downloads\widget.cdx.json`, "widget"},
+		{"https://user:password@example.org/path/widget.spdx.json?token=secret#fragment", "widget"},
+		{"s3://bucket/project%20name/file.SPDX.JSON", "project name/file"},
+		{"", "Unnamed SBOM"},
+		{"/tmp/tmp.ABC123xyz.json", "Unnamed SBOM"},
+		{"s3://bucket/", "Unnamed SBOM"},
+		{"https://%invalid", "Unnamed SBOM"},
+	} {
+		t.Run(tt.source, func(t *testing.T) {
+			got, err := Resolve([]byte(`{}`), "", tt.source)
+			if err != nil || got != tt.want {
+				t.Fatalf("got %q, %v; want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveInvalidJSON(t *testing.T) {
+	for _, data := range []string{`{`, `{"predicateType":"spdx","predicate":[]}`} {
+		if _, err := Resolve([]byte(data), "", "source.json"); err == nil {
+			t.Errorf("expected error for %s", data)
+		}
+	}
+}
+
+func TestResolveXMLUsesSource(t *testing.T) {
+	got, err := Resolve([]byte(`<?xml version="1.0"?><bom xmlns="http://cyclonedx.org/schema/bom/1.5"/>`), "", "widget.xml")
+	if err != nil || got != "widget.xml" {
+		t.Fatalf("got %q, %v; want source fallback for XML", got, err)
+	}
+}
+
+func TestResolutionLogPreservesOriginalWithoutSourceSecrets(t *testing.T) {
+	var output bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&output)
+	t.Cleanup(func() { log.SetOutput(previous) })
+	_, err := Resolve([]byte(`{}`), "tmp.ABC123xyz", "https://user:password@example.org/widget.json?token=secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	if !strings.Contains(text, `original="tmp.ABC123xyz"`) || !strings.Contains(text, `resolved="widget"`) {
+		t.Fatalf("missing name provenance: %s", text)
+	}
+	if strings.Contains(text, "password") || strings.Contains(text, "secret") {
+		t.Fatalf("source credentials leaked: %s", text)
+	}
+}

--- a/backend/internal/spdx/parser.go
+++ b/backend/internal/spdx/parser.go
@@ -11,6 +11,7 @@ import (
 	json "github.com/goccy/go-json"
 	"github.com/google/uuid"
 
+	"github.com/seebom-labs/bomhort/backend/internal/sbomname"
 	"github.com/seebom-labs/bomhort/backend/pkg/models"
 )
 
@@ -174,12 +175,17 @@ func Parse(r io.Reader, sourceFile, sha256Hash string) (result *ParseResult, err
 		tools = append(tools, c)
 	}
 
+	docName, err := sbomname.Resolve(data, doc.Name, sourceFile)
+	if err != nil {
+		return nil, err
+	}
+
 	sbom := models.SBOM{
 		IngestedAt:        now,
 		SBOMID:            sbomID,
 		SourceFile:        sourceFile,
 		SPDXVersion:       doc.SPDXVersion,
-		DocumentName:      doc.Name,
+		DocumentName:      docName,
 		DocumentNamespace: doc.DocumentNamespace,
 		SHA256Hash:        sha256Hash,
 		CreationDate:      creationDate,

--- a/docs/ARCHITECTURE_PLAN.md
+++ b/docs/ARCHITECTURE_PLAN.md
@@ -174,6 +174,31 @@ Angular UI (13 lazy-loaded routes, virtual scrolling, OnPush, dark mode)
        │ Custom CSS theme mountable without Angular rebuild
 ```
 
+### Document name fallback
+
+All three parser adapters use `internal/sbomname` to resolve empty or temporary
+document names before returning metadata to the worker. Meaningful existing names
+are preserved verbatim. For SPDX JSON (including the built-in in-toto path), the
+fallback uses exactly one explicitly described package from `documentDescribes`,
+document-originating `DESCRIBES`, or inverse `DESCRIBED_BY`, and appends its known
+version. Duplicate references are deduplicated; multiple, dangling, or duplicate
+package IDs do not cause an arbitrary dependency to be selected. Both parser
+backends inspect the same source metadata rather than relying on inferred graph roots.
+
+CycloneDX uses its metadata component, retaining the serial-number fallback.
+If there is no usable unambiguous root, use the S3 object key or local/HTTP basename
+without the SBOM JSON suffix, finally `Unnamed SBOM`. The extra JSON metadata pass
+is limited to unusable names; already parsed XML can fall back to its source label.
+Quoted, bounded logs record the original and resolved names. Raw source documents,
+source URIs, checksums, SBOM IDs, package arrays, and schemas are not changed.
+
+The resolved value is stored in the existing `document_name` column, not computed
+only by the UI. Existing rows therefore require re-processing; a watcher run alone
+does not bypass deduplication. Project-scoped license rules use this exact resolved
+name, including its version, without implicit aliases for the old `tmp.*` value.
+S3 project grouping continues to use the source path. See the
+[producer-facing fix report](reports/2026-09-08-temporary-sbom-document-names.md).
+
 ## 3. API Endpoints (25)
 
 | Method | Endpoint | Description |

--- a/docs/content/docs/api-reference/_index.md
+++ b/docs/content/docs/api-reference/_index.md
@@ -324,6 +324,16 @@ curl -X POST http://localhost:8080/api/v1/sboms/upload \
 
 Paginated list of all ingested SBOMs.
 
+**Document names:** `document_name` is the name stored at ingestion, also used by
+the detail and other SBOM-related endpoints. Meaningful source names are preserved.
+Empty or temporary names such as `tmp.ABC123xyz` fall back to a uniquely described
+root package plus version (for example `example-org/widget v1.2.3`), then a source
+label, finally `Unnamed SBOM`. See [the complete parser rules](/docs/development/parsers/#document-name-fallback).
+Source bytes, hashes, SBOM IDs, and the original download are unchanged; the API
+does not introduce a separate original-name field. Older rows retain their stored
+names until re-processed. Project-scoped license exceptions match the exact resolved
+`document_name`, including the version; old temporary names are not aliases.
+
 **Parameters:**
 
 | Parameter | Type | Default | Description |

--- a/docs/content/docs/architecture/_index.md
+++ b/docs/content/docs/architecture/_index.md
@@ -211,7 +211,15 @@ Two parser backends are available:
 - **Built-in (default)** — Lightweight, high-performance parsers using `goccy/go-json`. Zero additional dependencies. Best for production with known formats.
 - **Protobom (opt-in)** — Uses [github.com/protobom/protobom](https://github.com/protobom/protobom) for maximum format coverage. Enable with `USE_PROTOBOM=true`.
 
-See the [Parsers documentation](/docs/development/parsers/) for configuration details and trade-offs.
+Both backends use `internal/sbomname` to replace empty or temporary (`tmp.*`)
+document names with an unambiguous described root package and version, or a source
+label when no usable root exists. Meaningful names, raw SBOM bytes, source identity,
+and package data are preserved. This is applied during ingestion and stored in
+`document_name`; existing records need re-processing. Exact project-scoped license
+exceptions use the resolved name, while S3 project grouping remains source-based.
+
+See the [Parsers documentation](/docs/development/parsers/) for configuration details,
+fallback rules, upgrade implications, and trade-offs.
 
 ## GitHub License Resolution
 

--- a/docs/content/docs/development/parsers.md
+++ b/docs/content/docs/development/parsers.md
@@ -69,6 +69,50 @@ The [protobom](https://github.com/protobom/protobom) backend provides maximum fo
 - ❌ Does not handle in-toto envelopes out-of-the-box
 - ❌ Slight parsing overhead vs. the tuned built-in parsers
 
+## Document name fallback
+
+Both parser backends share `internal/sbomname` for empty or temporary SBOM names.
+For example, a source document named `tmp.ABC123xyz` describing
+`example-org/widget` version `v1.2.3` is stored and displayed as
+**`example-org/widget v1.2.3`**.
+
+The conservative rules are:
+
+1. Preserve a meaningful existing document name exactly, including existing formatting.
+   Fallback detection recognizes whitespace-only names, `tmp`, and
+   `tmp.` followed by at least six ASCII alphanumeric characters, including
+   absolute filesystem paths ending in that pattern. It does not rewrite names
+   merely containing `tmp`, such as `tmp-utils` or `org/tmp.tool`.
+2. For SPDX JSON, use exactly one explicitly described package from
+   `documentDescribes`, a `DESCRIBES` relationship originating at the document,
+   or a `DESCRIBED_BY` relationship targeting the document. Append its version
+   unless empty or `NOASSERTION`, `NONE`, or `UNKNOWN`.
+3. Do not guess from package array order or dependency-graph roots. Multiple or
+   dangling root references, duplicate package IDs, and temporary/empty root names
+   use the source fallback instead. Redundant references to the same root are fine.
+4. For CycloneDX JSON, use `metadata.component` name/version, then a usable
+   `serialNumber`. Ordinary dependencies are not treated as metadata components.
+5. Otherwise use the full S3 object key (preserving project/version context), or
+   the basename of a local/HTTP source, removing `.spdx.json`, `_spdx.json`,
+   `.cdx.json`, or `.json`. URL credentials, query strings, and fragments are not
+   part of the label. If no usable source remains, use `Unnamed SBOM`.
+
+The built-in in-toto parser applies the same rule to its SPDX predicate. This does
+not add in-toto support to protobom. For already parsed XML without a name, the
+shared helper uses the source fallback rather than attempting JSON root extraction.
+
+Original SBOM bytes, source URI, hash/ID, namespace, and package identities are
+unchanged. A bounded, quoted log entry records the original name, resolved name,
+and fallback reason. The original name remains available in the source SBOM;
+there is no new database column or raw-name API field.
+
+**Upgrade note:** the resolved name is persisted in `document_name`. Deploying
+new worker images does not rewrite existing rows: plan re-processing of existing
+SBOMs, with backups before any destructive development reset helper. Re-running
+the watcher alone skips unchanged files. Project-scoped license exceptions must
+use the exact resolved document name (including the version), not the old `tmp.*`
+name or the separately grouped S3 project label. No automatic scope aliases are added.
+
 ## Configuration
 
 ### Environment Variable
@@ -132,7 +176,7 @@ When `USE_PROTOBOM=true`, **all** SBOM parsing is routed through protobom — in
 |-----------------|-------------------|-------|
 | `specVersion` | `SBOM.SPDXVersion` | Stored as `"CycloneDX-1.5"` |
 | `serialNumber` | `SBOM.DocumentNamespace` | URN format |
-| `metadata.component.name` | `SBOM.DocumentName` | With version appended |
+| `metadata.component.name` | `SBOM.DocumentName` | With version appended; unusable names use the shared fallback above |
 | `metadata.timestamp` | `SBOM.CreationDate` | RFC3339 |
 | `metadata.tools[].name` | `SBOM.CreatorTools` | Prefixed with "Tool: " |
 | `components[].bom-ref` | `PackageSPDXIDs` | Used as node identifier |

--- a/docs/content/docs/faq/_index.md
+++ b/docs/content/docs/faq/_index.md
@@ -119,6 +119,24 @@ Changes to **VEX files** do **not** require a full re-ingestion. VEX matching is
 
 ---
 
+## Why are my SBOMs named `tmp.*`?
+
+Some producer pipelines put a temporary checkout-directory name into the SPDX
+document's top-level `name`, even when the S3 object key and described root package
+are correct. Renaming only the object does not correct these source metadata.
+
+BOMHort's built-in and protobom parsers now replace empty/temporary document names
+with an unambiguous described package name and version, or a source label when
+that is unavailable. Good names and original downloaded documents are not changed.
+See [Document name fallback](/docs/development/parsers/#document-name-fallback).
+
+If old entries still display `tmp.*`, deploy worker images containing the fix and
+plan re-processing of those SBOMs. An ordinary watcher run or Argo sync does not
+rewrite stored rows because unchanged files are deduplicated. Review project-scoped
+license exceptions against the new exact `document_name`, including its version.
+The producer should still fix its generated document name rather than relying only
+on downstream display fallbacks.
+
 ## How do I check ingestion progress?
 
 ```bash

--- a/docs/reports/2026-09-08-temporary-sbom-document-names.md
+++ b/docs/reports/2026-09-08-temporary-sbom-document-names.md
@@ -1,0 +1,159 @@
+# Bug report: generated SPDX document names expose temporary checkout names
+
+**Suggested issue title:** `fix: derive SPDX document names from repository identity, not temporary checkout directories`
+
+**Observed:** 2026-09-08
+
+## Summary
+
+SPDX documents in `cncf-project-sboms` and `cncf-subproject-sboms` have meaningful
+object keys and explicitly described root packages, but their top-level `name`
+contains a random temporary-directory name such as `tmp.PM9IVSVGio`.
+
+This value is present in the downloaded source JSON before BOMHort processes it.
+Both BOMHort parser backends previously preserved it as the document title, making
+individual SBOMs appear to be named `tmp.*` despite valid repository metadata.
+Renaming the bucket object alone does not fix the JSON document name.
+
+The producer metadata identifies Waybill 0.2.0 and 0.3.0. **The producer source code
+and exact generator invocation were not inspected**, so it is not yet established
+whether the incorrect name is set by Waybill itself or its calling pipeline.
+
+## Evidence and scope
+
+The checks were read-only: complete object listings, selected downloads, and local
+parsing. No bucket objects, running deployments, or database records were changed.
+Credentials and infrastructure-specific connection details are intentionally omitted.
+
+| Bucket | Listed objects | Object keys containing `tmp` | Contents sampled | Top-level `name` matching `tmp.*` |
+|---|---:|---:|---:|---:|
+| `cncf-project-sboms` | 2,026 | 0 | 24 | 24/24 |
+| `cncf-subproject-sboms` | 13,025 | 0 | 24 | 24/24 |
+
+- All 48 sampled contents are plain SPDX 2.3 JSON, not in-toto envelopes.
+- All have usable explicitly described root packages with repository names and versions.
+- 35 samples identify `Tool: waybill-0.2.0`; 13 identify `Tool: waybill-0.3.0`.
+- The sample includes objects updated on 2026-09-07, so it is not limited to old uploads.
+- Sampling covered different source/project groups, selecting the latest object
+  per chosen group, plus the first object and latest object overall in each bucket.
+  Selection was deterministic; files larger than 16 MiB were excluded from content
+  sampling. About 72.6 MB of sample content was downloaded.
+- **All 15,051 object keys were listed, but not all 15,051 document contents were
+  examined.** The 48/48 result is a sample finding, not a full-content census.
+
+### Reproducible examples
+
+| Bucket / object key | Actual document `name` | Described root package | Root version |
+|---|---|---|---|
+| `cncf-project-sboms/aeraki-mesh/1.0.5/aeraki-mesh_1_0_5_spdx.json` | `tmp.PM9IVSVGio` | `aeraki-mesh/aeraki` | `1.0.5` |
+| `cncf-project-sboms/werf/3.3.1/werf_3_3_1_spdx.json` | `tmp.X3TNVswW6Y` | `werf/werf` | `v3.3.1` |
+| `cncf-subproject-sboms/aeraki/meta-protocol-proxy/1.1.4/aeraki_meta-protocol-proxy_1_1_4_spdx.json` | `tmp.PxbREcw4zw` | `aeraki-mesh/meta-protocol-proxy` | `1.1.4` |
+| `cncf-subproject-sboms/lima/socketvmnet/1.2.2/lima_socketvmnet_1_2_2_spdx.json` | `tmp.9agbSqURkZ` | `lima-vm/socket_vmnet` | `v1.2.2` |
+
+These are observed source values, not proposed replacement package identities.
+
+## Reproduction
+
+1. Download one of the listed objects using the repository's normal authorized
+   storage tooling. Do not paste access keys into an issue, script, or log.
+2. Inspect its top-level name and explicitly described roots:
+
+   ```bash
+   jq '
+     . as $doc |
+     (($doc.documentDescribes // []) +
+       [$doc.relationships[]? |
+        select(.relationshipType == "DESCRIBES" and .spdxElementId == $doc.SPDXID) |
+        .relatedSpdxElement]) | unique as $rootIDs |
+     {name: $doc.name, creators: $doc.creationInfo.creators,
+      roots: [$doc.packages[]? |
+              select(.SPDXID as $id | $rootIDs | index($id)) |
+              {SPDXID, name, versionInfo}]}
+   ' downloaded.spdx.json
+   ```
+
+3. Compare the temporary document name to the meaningful root package and version.
+4. To trace the producer defect, generate the same repository/ref in two differently
+   named checkout directories and compare only the document names. This producer
+   reproduction is a recommended next step; it was not run during the bucket test.
+
+## Expected behavior
+
+The document name should identify the software being described, independently of
+the temporary working directory used to scan it. For example:
+
+- `aeraki-mesh/aeraki 1.0.5`
+- `werf/werf v3.3.1`
+- `lima-vm/socket_vmnet v1.2.2`
+
+A consistent producer naming convention can differ in formatting, but should be
+stable for the same repository/ref and must not contain the temporary checkout name.
+
+## Recommended producer fix
+
+1. Trace where the top-level SPDX `name` is assigned. Check whether a temporary
+   checkout basename is being used as the scan target/document title.
+2. Supply the intended repository/project identity and the exact scanned ref/version
+   when constructing the document. Prefer the existing explicit root metadata over
+   guessing from arbitrary dependency names or replacing every occurrence of `tmp`.
+3. Keep `documentDescribes` / document-to-package `DESCRIBES` references consistent
+   with the actual root package. Do not assume `packages[0]` is always the root.
+4. Change document-title metadata only as needed. Do not accidentally rename packages,
+   rewrite PURLs, change dependency relationships, or broaden license statements.
+   Normal document regeneration may of course change checksums and provenance.
+5. Add a pre-upload validation gate that detects empty/temporary document titles
+   and reports the affected repository/ref. Re-generate affected artifacts through
+   the normal publication pipeline after reviewing its retention/versioning policy.
+
+### Acceptance criteria
+
+- [ ] The same repository/ref scanned in two different temporary directories yields
+      the same meaningful document name.
+- [ ] The generated name identifies the intended project and, when known, its version.
+- [ ] Root selection is explicit and remains correct if package array order changes.
+- [ ] Missing/multiple roots are handled deliberately; no arbitrary dependency is
+      promoted to the document identity.
+- [ ] Existing meaningful names and package/PURL/license/relationship data are preserved.
+- [ ] The upload pipeline rejects or explicitly flags empty/temporary names.
+- [ ] Representative project and subproject artifacts are re-generated and checked
+      directly from object storage, not only through a consumer UI.
+
+These are proposed upstream acceptance criteria, not claims that the producer has
+already been patched.
+
+## BOMHort mitigation implemented alongside this report
+
+BOMHort now has a shared `internal/sbomname` fallback in its built-in SPDX,
+CycloneDX, and protobom adapters:
+
+- Preserve meaningful document names verbatim.
+- For an empty or temporary SPDX name, choose a single explicitly described root
+  package and append its known version. Duplicate references to that same root are
+  allowed; multiple/dangling references and duplicate package IDs use a source label.
+- Fall back to the S3 object key or local/HTTP basename if no usable root exists,
+  and finally `Unnamed SBOM`. CycloneDX retains its metadata-component/serial-number
+  preference. No package identity is changed by this document-name fallback.
+- Log bounded, quoted original/resolved names for diagnosis while retaining the
+  original source bytes and source identity. No database schema change is required.
+
+### Consumer-side verification
+
+| Parser | Before mitigation | After mitigation |
+|---|---|---|
+| Built-in | 48/48 samples retained `tmp.*` document names | 48/48 resolve to their expected root name and version |
+| Protobom | 48/48 samples retained `tmp.*` document names | 48/48 resolve to their expected root name and version |
+
+The post-fix check replayed the previously downloaded samples **offline**; no new
+storage credentials or producer changes were required. Source files were unchanged.
+Committed synthetic regression tests cover temporary/empty and valid names,
+root ambiguity, in-toto (built-in), CycloneDX, source fallback, unchanged package
+identity, and exact license-exception project scopes.
+
+The mitigation is applied during ingestion, not solely in the UI. Existing BOMHort
+rows require planned re-processing; a pod restart, Argo sync, or watcher-only run
+does not bypass deduplication or rewrite stored results. Project-scoped license
+exceptions must use the resolved document name including its version; old `tmp.*`
+names are not implicitly granted aliases.
+
+This consumer fallback is defensive handling and does **not** replace fixing the
+producer metadata for other SBOM consumers.


### PR DESCRIPTION
## Description

**Bugfix:** replace unusable SBOM document names with meaningful, deterministic fallback names during ingestion.

A read-only investigation of `cncf-project-sboms` and `cncf-subproject-sboms` found no `tmp` object keys among 15,051 listed objects, but all 48 sampled SPDX documents already contained a top-level `name` such as `tmp.PM9IVSVGio`. Their explicitly described root packages contained meaningful repository names and versions. Both BOMHort parser backends previously propagated the temporary document name unchanged.

### Implementation

- Add shared `internal/sbomname` resolution to the built-in SPDX, CycloneDX, and protobom adapters.
- Preserve meaningful existing document names verbatim. Only empty/whitespace-only names, `tmp`, and conservative `tmp.<alphanumeric suffix>` directory patterns trigger fallback.
- For SPDX, resolve exactly one explicitly described package using `documentDescribes`, document-originating `DESCRIBES`, or inverse `DESCRIBED_BY`, and append its known version. Deduplicate redundant references; do not choose arbitrary dependencies for missing, multiple, dangling, or duplicate-ID roots.
- Retain CycloneDX metadata-component/serial-number preference; otherwise use a source label, finally `Unnamed SBOM`. Already parsed XML without a name uses a source fallback rather than failing JSON metadata extraction.
- Preserve raw source bytes, source URI, hashes/SBOM IDs, namespaces, and package identities. Log bounded, quoted original/resolved names and omit source URL credentials/query parameters from fallback labels.
- Add synthetic regression fixtures, shared-helper tests, and cross-backend tests covering metadata preservation and exact license-exception project scopes.
- Update architecture, parser, API, and FAQ documentation and add a producer-facing fix report at `docs/reports/2026-09-08-temporary-sbom-document-names.md`, including concrete observations, a verified reproduction command, proposed producer changes, and acceptance criteria.

### Compatibility / rollout

The resolved value is stored in the existing `document_name` column. Existing rows require planned re-processing: deploying new images, an Argo sync, or re-running the watcher alone does not bypass hash deduplication. Project-scoped license exceptions must match the exact resolved name, including its version; old temporary names are not implicitly granted aliases. S3 project grouping remains source-path-based.

This is a bugfix, but the observable name and exact project-scope changes are explicitly marked below for operators. No database migration, new dependency, producer-repository modification, automatic data reset, or deployment is included.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🏗️ Infrastructure / CI / Helm

The breaking-change checkbox highlights the corrected `document_name` values and exact license-project matching implications; meaningful existing names and API response structure remain unchanged.

## Component(s) Affected

- [x] API Gateway
- [x] Parsing Worker
- [ ] Ingestion Watcher
- [ ] ClickHouse Schema / Migrations
- [ ] Angular UI
- [ ] Helm Chart
- [x] Documentation

API impact is the documented `document_name` value returned from ingested records; no API handler or Angular source changes are required.

## Related Issues

Relates to #310: project-scoped license exceptions must continue to match exact document names without implicit aliases.

No producer issue number is available yet. The producer-facing report is included for filing separately; it distinguishes observed Waybill-generated metadata from the unverified producer implementation cause.

## How Has This Been Tested?

- [x] `go test ./...` passes
- [ ] `ng build` passes
- [x] `helm lint` passes
- [ ] Manual testing via Docker Compose
- [ ] Manual testing on Kubernetes

Additional validation:

- `go test ./... -count=1 -race`, `go build ./...`, and `go vet ./...` pass.
- Shared-helper and cross-backend tests cover valid/empty/temporary names, root selection and ambiguity, source fallback, built-in in-toto handling, CycloneDX, unchanged source/package identities, and exact license-project matching.
- Replayed all 48 previously downloaded original SPDX samples **offline** through both real parser backends. Built-in: 48/48 expected root names with versions; protobom: 48/48. Original sample files remain unchanged.
- Hugo documentation build passes, and the document-name-fallback anchor exists in generated output.
- Executed the report's `jq` reproduction command against an original sample and verified its temporary document name and meaningful described root.
- `git diff --cached --check` passes.

No frontend source changes were made, so an Angular rebuild was not repeated for this PR. No live Kubernetes/Argo deployment or database re-ingestion was performed. The 48/48 finding is a content sample, not a claim that all 15,051 objects were fully downloaded or parsed.

## Checklist

- [x] My code follows the project's coding standards ([AGENTS.md](AGENTS.md))
- [x] I have added tests that prove my fix/feature works ([docs/TESTING.md](docs/TESTING.md))
- [x] New and existing unit tests pass locally
- [x] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [x] I have signed off my commits (DCO)

Warning note: the Hugo build emits existing `languageCode` / `LanguageDirection` deprecation warnings. The warning-free checkbox is conservatively left unchecked; builds and tests pass.

## Screenshots (if applicable)

No screenshots captured; no Angular source changes. Verified example: `tmp.PM9IVSVGio` now resolves to `aeraki-mesh/aeraki 1.0.5`, and `tmp.X3TNVswW6Y` to `werf/werf v3.3.1`.

