### PR TITLE
ci: Disable Docker build record uploads

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -52,6 +52,9 @@ jobs:
 
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          # Build traces can contain signed storage URLs.
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
         with:
           context: ${{ matrix.component.context }}
           target: ${{ matrix.component.target || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Build and push
         id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          # Build traces can contain signed storage URLs.
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
         with:
           context: ${{ matrix.component.context }}
           target: ${{ matrix.component.target || '' }}


### PR DESCRIPTION
## Description

Docker build records can contain signed storage URLs captured in build traces. Set `DOCKER_BUILD_RECORD_UPLOAD: "false"` on all 2 Docker build-action steps in `release.yml`, `pre-release.yml` to stop publishing these archives while keeping build summaries enabled.

## Type of Change

- [x] Infrastructure / CI / Helm

## How Has This Been Tested?

- Parsed the workflows and verified every Docker build-action step disables record uploads.
- Verified the diff contains only the environment setting and its explanatory comment.
- `git diff --check` passed.
- `actionlint` passed for the changed workflows.

## Checklist

- [x] Follows project coding standards.
- [x] Workflow configuration validated; no application code changed.
- [x] No new warnings introduced.
- [x] Commits are signed off (DCO).
